### PR TITLE
Support to kong 0.11.x onwards

### DIFF
--- a/kong/CHANGELOG.md
+++ b/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - kong
 
+1.0.1 / 2018-01-12
+==================
+
+### Changes
+
+* [BUGFIX] Fix database metrics for 0.11.x version
+
 1.0.0 / 2017-03-22
 ==================
 

--- a/kong/check.py
+++ b/kong/check.py
@@ -72,8 +72,14 @@ class Kong(AgentCheck):
 
         # Then the database metrics
         databases_metrics = parsed.get('database').items()
-        output.append((self.METRIC_PREFIX + 'table.count', len(databases_metrics), tags))
+        db_output_lines = 0
         for name, items in databases_metrics:
-            output.append((self.METRIC_PREFIX + 'table.items', items, tags + ['table:{}'.format(name)]))
+            if isinstance(items, (float, int)) and not isinstance(items, bool):
+                output.append((self.METRIC_PREFIX + 'table.items', items, tags + ['table:{}'.format(name)]))
+                db_output_lines += 1
+            else:
+                self.log.debug(u"Ignoring databases pair: {} {}".format(name, items))
+        if db_output_lines > 0:
+            output.append((self.METRIC_PREFIX + 'table.count', db_output_lines, tags))
 
         return output

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -13,5 +13,5 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
They removed the number of items and the number of metrics in 0.11 release so we removed it from sending it which is useless.

See the difference:
* https://getkong.org/docs/0.10.x/admin-api/#retrieve-node-status
* https://getkong.org/docs/0.11.x/admin-api/#retrieve-node-status

Check the metrics sent using `sudo -u sd-agent /usr/share/python/sd-agent/agent.py check kong` before and after this change.

Use https://hub.docker.com/_/kong/ to test it out