### PR TITLE
Suggest username and password instead of connection string

### DIFF
--- a/mongo/conf.yaml.example
+++ b/mongo/conf.yaml.example
@@ -2,8 +2,10 @@ init_config:
 
 instances:
   # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
-  # E.g. mongodb://serverdensity:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27016/my-db
-  - server: mongodb://user:pass@host:port/db-name
+  # E.g. mongodb://localhost:27016/my-db
+  - server: mongodb://host:port/db-name
+    username: serverdensity
+    password: supersecurepassword
     # Controls connectTimeoutMS, serverSelectionTimeoutMS and socketTimeoutMS (see http://api.mongodb.com/python/3.4.0/api/pymongo/mongo_client.html)
     # Defaults to 30 seconds
     # timeout: 30

--- a/tokumx/conf.yaml.example
+++ b/tokumx/conf.yaml.example
@@ -2,8 +2,10 @@ init_config:
 
 instances:
   # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
-  # E.g. mongodb://serverdensity:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27017/my-db
+  # E.g. mongodb://localhost:27017/my-db
   - server: mongodb://localhost:27017
+    username: serverdensity
+    password: supersecurepassword
     # tags:
     #   - optional_tag1
     #   - optional_tag2


### PR DESCRIPTION
This PR brings a minor change to the Mongo and TokuMX config files, suggesting users make use of the user and password options instead of using a connection string on the server option as the server option is automatically used as a tag, exposing the user and password in the UI. 

cc @serverdensity/backend-engineering 