### PR TITLE
Update process metrics 

### DIFF
--- a/process/check.py
+++ b/process/check.py
@@ -384,7 +384,7 @@ class ProcessCheck(AgentCheck):
         tags.extend(['process_name:%s' % name, name])
 
         self.log.debug('ProcessCheck: process %s analysed', name)
-        self.gauge('system.processes.number', len(pids), tags=tags)
+        self.gauge('system.processes.instances', len(pids), tags=tags)
 
         if len(pids) == 0:
             self.warning("No matching process '%s' was found" % name)

--- a/process/metadata.csv
+++ b/process/metadata.csv
@@ -13,7 +13,7 @@ system.processes.mem.pct,gauge,,percent,,The process memory consumption.,0,proce
 system.processes.mem.real,gauge,,byte,,The non-swapped physical memory a process has used and cannot be shared with another process.,0,processes,processes mem real
 system.processes.mem.rss,gauge,,byte,,"The non-swapped physical memory a process has used. aka ""Resident Set Size"".",0,processes,processes mem rss
 system.processes.mem.vms,gauge,,byte,,"The total amount of virtual memory used by the process. aka ""Virtual Memory Size"".",0,processes,processes mem vms
-system.processes.number,gauge,,process,,The number of processes.,0,processes,processes number
+system.processes.instances,gauge,,process,,The number of processes.,0,processes,processes number
 system.processes.open_file_descriptors,gauge,,,,The number of file descriptors used by this process.,0,processes,processes open fds
 system.processes.open_handles,gauge,,,,The number of handles used by this process.,0,processes,processes open handles
 system.processes.threads,gauge,,thread,,The number of threads used by this process.,0,processes,processes threads

--- a/process/test_process.py
+++ b/process/test_process.py
@@ -159,7 +159,7 @@ class ProcessCheckTest(AgentCheckTest):
         'system.processes.mem.real',
         'system.processes.mem.rss',
         'system.processes.mem.vms',
-        'system.processes.number',
+        'system.processes.instances',
         'system.processes.open_file_descriptors',
         'system.processes.threads',
         'system.processes.voluntary_ctx_switches',
@@ -314,10 +314,10 @@ class ProcessCheckTest(AgentCheckTest):
                 expected_value = None
                 # - if no processes are matched we don't send metrics except number
                 # - it's the first time the check runs so don't send cpu.pct
-                if (len(mocked_processes) == 0 and mname != 'system.processes.number'):
+                if (len(mocked_processes) == 0 and mname != 'system.processes.instances'):
                     continue
 
-                if mname == 'system.processes.number':
+                if mname == 'system.processes.instances':
                     expected_value = len(mocked_processes)
 
                 self.assertMetric(
@@ -376,7 +376,7 @@ class ProcessCheckTest(AgentCheckTest):
 
         self.run_check(config, mocks={'_get_child_processes': self.mock_get_child_processes})
 
-        self.assertMetric('system.processes.number', 4, tags=self.generate_expected_tags(config['instances'][0]))
+        self.assertMetric('system.processes.instances', 4, tags=self.generate_expected_tags(config['instances'][0]))
 
     def test_check_missing_pid(self):
         config = {
@@ -512,7 +512,7 @@ class ProcessCheckTest(AgentCheckTest):
         expected_tags = self.generate_expected_tags(config['instances'][0])
         self.assertServiceCheckOK('process.up', count=1, tags=expected_tags + ['process:moved_procfs'])
 
-        self.assertMetric('system.processes.number', at_least=1, tags=expected_tags)
+        self.assertMetric('system.processes.instances', at_least=1, tags=expected_tags)
         self.assertMetric('system.processes.threads', at_least=1, tags=expected_tags)
         self.assertMetric('system.processes.run_time.avg', at_least=1, tags=expected_tags)
         self.assertMetric('system.processes.run_time.max', at_least=1, tags=expected_tags)


### PR DESCRIPTION
This PR changes the metric name `system.processes.number` to `system.processes.instances` in the process check. 

The check, meadata and tests have all been updated. 

This is to prevent a clash with the untagged `system.processes.number` metric.

cc @serverdensity/backend-engineering 