### PR TITLE
Add monotonic_count to custom query metrics

### DIFF
--- a/mysql/check.py
+++ b/mysql/check.py
@@ -727,6 +727,9 @@ class MySql(AgentCheck):
                                 elif metric_type == RATE:
                                     self.rate(metric, float(
                                         result[col_idx]), tags=tags)
+                                elif metric_type == MONOTONIC:
+                                    self.monotonic_count(metric, float(
+                                        result[col_idx]), tags=tags)
                                 else:
                                     self.gauge(metric, float(
                                         result[col_idx]), tags=tags)


### PR DESCRIPTION
This PR adds the monotonic_count metric type to the MySQL check for custom query metrics.

@sixstone-qq to review please. 