### PR TITLE
Add systemd version of `sd-agent info` to the instructions

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -17,7 +17,7 @@ Edit the `kubernetes.yaml` file to point to your server and port, set the master
 
 ## Validation
 
-When you run `sd-agent info` you should see something like the following:
+When you run `sd-agent info` you should see something like the following output. If you are on a systemd-based system, you should run `/usr/share/python/sd-agent/agent.py info` instead.
 
     Checks
     ======


### PR DESCRIPTION
I'm new to ServerDensity and couldn't figure out how to run `sd-agent info` on Ubuntu. I've updated the instructions so that it mentions what to do if you're on a systemd-based system.