### PR TITLE
Add rmq cluster_status service check

### DIFF
--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changes
 
-* [FEATURE] Add a service check for the cluster status.
+* [FEATURE] Add a check for the number of running nodes in a cluster.
 
 1.2.0 / 2017-07-18
 ==================

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - rabbitmq
 
+1.3.0 / 2018-07-05
+==================
+
+### Changes
+
+* [FEATURE] Add a service check for the cluster status.
+
 1.2.0 / 2017-07-18
 ==================
 

--- a/rabbitmq/check.py
+++ b/rabbitmq/check.py
@@ -402,3 +402,4 @@ class RabbitMQ(AgentCheck):
                 running_nodes += 1
 
         self.gauge(u'rabbitmq.running_nodes', running_nodes, tags=custom_tags)
+

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -13,5 +13,5 @@
     "mac_os",
     "windows"
   ],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -26,3 +26,4 @@ rabbitmq.queue.messages.redeliver.count,gauge,,message,,Count of subset of messa
 rabbitmq.queue.messages.redeliver.rate,gauge,,message,second,Rate per second of subset of messages in deliver_get which had the redelivered flag set,0,rabbitmq,msgs redelv rate
 rabbitmq.connections,gauge,,connection,,"Number of current connections to a given rabbitmq vhost, tagged 'rabbitmq_vhost:<vhost_name>'",0,rabbitmq,connections
 rabbitmq.connections.state,gauge,,connection_state,,Number of connections in the specified connection state,0,rabbitmq,connection_state
+rabbitmq.running_nodes,gauge,,node,,Number of running nodes in a cluster,0,rabbitmq,running_nodes


### PR DESCRIPTION
Use the /api/nodes endpoint to get all cluster nodes and check if they are running. The service check fails if any node in the cluster is not running.

@pessoa 