### PR TITLE
Fix sd-agent-ssh-check dependencies

### DIFF
--- a/debian/sd-agent-pyasn1-common.install
+++ b/debian/sd-agent-pyasn1-common.install
@@ -1,1 +1,2 @@
 debian/build/lib/python2.7/site-packages/pyasn1*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/asn1crypto*  usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/debian/sd-agent-ssh-check.install
+++ b/debian/sd-agent-ssh-check.install
@@ -7,3 +7,5 @@ debian/build/lib/python2.7/site-packages/Crypto*  usr/share/python/sd-agent/lib/
 debian/build/lib/python2.7/site-packages/enum*  usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/_cffi_backend.so  usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/idna* usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/cffi* usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/pycparser* usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/packaging/el/inc/install
+++ b/packaging/el/inc/install
@@ -7,10 +7,8 @@ mkdir -p %{buildroot}/usr/share/python/sd-agent/lib/python%{__sd_python_version}
 cp -a %{__venv}/lib/python%{__sd_python_version}/site-packages %{buildroot}/usr/share/python/sd-agent/lib/python%{__sd_python_version}
 
 rm -Rf %{buildroot}/etc/sd-agent/conf.d/auto_conf
-rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/asn1crypto*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/argparse*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/certifi*
-rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/cffi*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/chardet*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/dns*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/easy-install.pth
@@ -25,8 +23,6 @@ rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/pip*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/ply*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/protobuf*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/psutil*
-#rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/psycopg*
-rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/pycparser*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/pycryptodome*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/pysmi*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/python*

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -832,7 +832,7 @@ This package installs the SD CPU Stats plugin.
 %package -n sd-agent-snmp
 Summary: Server Density Monitoring Agent. snmp plugin
 Group: System/Monitoring
-Requires: %{name} >= 2.2.0
+Requires: %{name} >= 2.2.0, sd-agent-pyasn1-common
 BuildArch: noarch
 
 %description -n sd-agent-snmp
@@ -844,7 +844,21 @@ This package installs the snmp plugin.
 /usr/share/python/sd-agent/checks.d/snmp.py
 %config /etc/sd-agent/conf.d/snmp.yaml.example
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/pysnmp*
+
+%package -n sd-agent-pyasn1-common
+Summary: The Server Density monitoring agent - common pyasn1 libs
+Group: System/Monitoring
+Requires: %{name} >= 2.2.0
+BuildArch: noarch
+
+%description -n sd-agent-pyasn1-common
+%{longdescription}
+This package installs the common pyasn1 libs.
+
+%files -n sd-agent-pyasn1-common
+%defattr(-,root,root,-)
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/pyasn1*
+/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/asn1crypto*
 
 %package -n sd-agent-solr
 Summary: Server Density Monitoring Agent. solr plugin
@@ -880,7 +894,7 @@ This package installs the spark plugin.
 %package -n sd-agent-ssh-check
 Summary: Server Density Monitoring Agent. ssh_check plugin
 Group: System/Monitoring
-Requires: %{name} >= 2.2.0
+Requires: %{name} >= 2.2.0, sd-agent-pyasn1-common
 
 %description -n sd-agent-ssh-check
 %{longdescription}
@@ -895,8 +909,9 @@ This package installs the ssh_check plugin.
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/Crypto*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/enum*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/_cffi_backend.so
-/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/pyasn1*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/idna*
+/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/cffi*
+/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/pycparser*
 
 %package -n sd-agent-statsd
 Summary: Server Density Monitoring Agent. statsd plugin


### PR DESCRIPTION
This PR fixes the dependency issues found with the sd-agent-ssh-agent & sd-agent-pyasn1-common agent packages during QA.