### PR TITLE
SSH-Check: Paramiko version bump

### DIFF
--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -216,7 +216,7 @@ Description: The Server Density monitoring agent - system-swap plugin
 
 Package: sd-agent-ssh-check
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), libffi6
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
 Recommends: sd-agent-pyasn1-common
 Description: The Server Density monitoring agent - ssh_check plugin
  Monitor SSH connectivity and SFTP latency.

--- a/debian/distros/jessie/control
+++ b/debian/distros/jessie/control
@@ -216,7 +216,7 @@ Description: The Server Density monitoring agent - system-swap plugin
 
 Package: sd-agent-ssh-check
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), libffi6
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
 Recommends: sd-agent-pyasn1-common
 Description: The Server Density monitoring agent - ssh_check plugin
  Monitor SSH connectivity and SFTP latency.

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -216,7 +216,7 @@ Description: The Server Density monitoring agent - system-swap plugin
 
 Package: sd-agent-ssh-check
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), libffi6
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
 Recommends: sd-agent-pyasn1-common
 Description: The Server Density monitoring agent - ssh_check plugin
  Monitor SSH connectivity and SFTP latency.

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -216,7 +216,7 @@ Description: The Server Density monitoring agent - system-swap plugin
 
 Package: sd-agent-ssh-check
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), libffi6
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
 Recommends: sd-agent-pyasn1-common
 Description: The Server Density monitoring agent - ssh_check plugin
  Monitor SSH connectivity and SFTP latency.

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -216,7 +216,7 @@ Description: The Server Density monitoring agent - system-swap plugin
 
 Package: sd-agent-ssh-check
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), libffi6
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
 Recommends: sd-agent-pyasn1-common
 Description: The Server Density monitoring agent - ssh_check plugin
  Monitor SSH connectivity and SFTP latency.

--- a/debian/sd-agent-ssh-check.install
+++ b/debian/sd-agent-ssh-check.install
@@ -6,6 +6,5 @@ debian/build/lib/python2.7/site-packages/cryptography*  usr/share/python/sd-agen
 debian/build/lib/python2.7/site-packages/Crypto*  usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/enum*  usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/_cffi_backend.so  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/idna* usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/cffi* usr/share/python/sd-agent/lib/python2.7/site-packages
 debian/build/lib/python2.7/site-packages/pycparser* usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/packaging/el/inc/install
+++ b/packaging/el/inc/install
@@ -15,6 +15,7 @@ rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/easy-i
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/google*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/gridfs*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/ipaddress*
+rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/idna*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/kazoo*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/meld3*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/memcache.pyc

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -909,7 +909,6 @@ This package installs the ssh_check plugin.
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/Crypto*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/enum*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/_cffi_backend.so
-/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/idna*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/cffi*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/pycparser*
 

--- a/ssh_check/requirements.txt
+++ b/ssh_check/requirements.txt
@@ -1,3 +1,3 @@
 # integration pip requirements
-paramiko==2.1.5
+paramiko==2.1.6
 cryptography==2.3


### PR DESCRIPTION
This PR updates the paramiko dependency in the ssh-check to address CVE-2018-1000805. 

The idna module has been removed from the check as this will now be provided by agent version 2.2.2, this version of ssh-check now requires a minimum of agent 2.2.2 

Packages tested on stage and working as expected.