### PR TITLE
HTTP-Check: Requests version bump 

### DIFF
--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -329,7 +329,7 @@ Description: The Server Density monitoring agent - statsd plugin
 
 Package: sd-agent-http-check
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
 Description: The Server Density monitoring agent - http_check plugin
  http_check description.
  .

--- a/debian/distros/jessie/control
+++ b/debian/distros/jessie/control
@@ -329,7 +329,7 @@ Description: The Server Density monitoring agent - statsd plugin
 
 Package: sd-agent-http-check
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
 Description: The Server Density monitoring agent - http_check plugin
  http_check description.
  .

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -329,7 +329,7 @@ Description: The Server Density monitoring agent - statsd plugin
 
 Package: sd-agent-http-check
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
 Description: The Server Density monitoring agent - http_check plugin
  http_check description.
  .

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -329,7 +329,7 @@ Description: The Server Density monitoring agent - statsd plugin
 
 Package: sd-agent-http-check
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
 Description: The Server Density monitoring agent - http_check plugin
  http_check description.
  .

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -329,7 +329,7 @@ Description: The Server Density monitoring agent - statsd plugin
 
 Package: sd-agent-http-check
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
 Description: The Server Density monitoring agent - http_check plugin
  http_check description.
  .

--- a/http_check/check.py
+++ b/http_check/check.py
@@ -131,6 +131,8 @@ def get_ca_certs_path():
     """
     Get a path to the trusted certificates of the system
     """
+    ca_certs = ['/etc/ssl/certs/ca-certificates.crt']
+
     try:
         import tornado
     except ImportError:
@@ -155,8 +157,9 @@ class HTTPCheck(NetworkCheck):
     def __init__(self, name, init_config, agentConfig, instances):
         NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
 
-        self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
-
+        self.ca_certs = init_config.get('ca_certs')
+        if not self.ca_certs:
+            self.ca_certs = get_ca_certs_path()
 
     def _load_conf(self, instance):
         # Fetches the conf

--- a/http_check/requirements.txt
+++ b/http_check/requirements.txt
@@ -1,4 +1,4 @@
 # integration pip requirements
 # note: requests is also used in many checks
 # upgrade with caution
-requests==2.11.1
+requests==2.20.0

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -391,7 +391,7 @@ This package installs the hdfs_namenode plugin.
 %package -n sd-agent-http-check
 Summary: Server Density Monitoring Agent. http_check plugin
 Group: System/Monitoring
-Requires: %{name} >= 2.2.0
+Requires: %{name} >= 2.2.2
 BuildArch: noarch
 
 %description -n sd-agent-http-check


### PR DESCRIPTION
This PR updates the requests dependency in the http-check to address CVE-2018-18074.

This version of http-check now requires a minimum of agent 2.2.2. 

Packages tested on stage and working as expected.