### PR TITLE
Remove init_config param from KubeUtil instance, remove undefined init_success, remove undefined is_leader

### DIFF
--- a/kubernetes/conf.yaml.example
+++ b/kubernetes/conf.yaml.example
@@ -94,6 +94,8 @@ instances:
   # collect_events: false
 
   # Leader election
+  # *** Currently this does not work - the required functions are missing from the underlying
+  # KubeUtil libs to perform leader election ***
   #
   # Agents can perform leader election among themselves.
   # The leader agent will collect events from the apiserver


### PR DESCRIPTION
The kubernetes sd-agent plugin does not work, this `fixes` the plugin in the most simple way - the underlying issue is that the KubeUtil libs used by this plugin don't have the methods the plugin is trying to use, they are: 

- init_config (KubeUtil does not have an init param named init_config)
- init_success (KubeUtil does not have this method)
- is_leader (KubeUtil does not have this method)
