### PR TITLE
V2.5.3 - move prometheus_client to sd-agent packaging 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - PIP_CACHE=$HOME/.cache/pip
   - VOLATILE_DIR=/tmp
   - DD_CASHER_DIR=/tmp/casher
-  - AGENT_VERSION=2.5.2
+  - AGENT_VERSION=2.5.3
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el6=$CACHE_DIR/el6.tar.gz
   - CACHE_FILE_el6_i386=$CACHE_DIR/el6_i386.tar.gz

--- a/.travis/dockerfiles/bionic/entrypoint.sh
+++ b/.travis/dockerfiles/bionic/entrypoint.sh
@@ -21,6 +21,7 @@ for ARCH in amd64 i386; do
     if [ ! -d /packages/${DISTRO}/${RELEASE}/${ARCH} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}/${ARCH}
     fi
+    pbuilder-dist $RELEASE $arch update
     pbuilder-dist ${RELEASE} ${ARCH} build \
     --buildresult /packages/${DISTRO}/${RELEASE}/${ARCH} *${RELEASE}*.dsc
 done;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent-core-plugins (2.5.3-1trusty0) trusty; urgency=medium
+
+  * Update virtualenv packaging
+
+ -- Server Density <hello@serverdensity.com>  Mon, 4 Mar 2019 18:00:00 +0100
+
 sd-agent-core-plugins (2.5.2-1trusty0) trusty; urgency=medium
 
   * Added a 10s default timeout to the MySQL check.

--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -35,7 +35,8 @@ Description: The Server Density monitoring agent - Entropy plugin
 
 Package: sd-agent-cockroachdb
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
 Description: The Server Density monitoring agent - CockroachDB plugin
  Collects CockroachDB metrics.
  .

--- a/debian/distros/jessie/control
+++ b/debian/distros/jessie/control
@@ -35,7 +35,8 @@ Description: The Server Density monitoring agent - Entropy plugin
 
 Package: sd-agent-cockroachdb
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
 Description: The Server Density monitoring agent - CockroachDB plugin
  Collects CockroachDB metrics.
  .

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -35,7 +35,8 @@ Description: The Server Density monitoring agent - Entropy plugin
 
 Package: sd-agent-cockroachdb
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
 Description: The Server Density monitoring agent - CockroachDB plugin
  Collects CockroachDB metrics.
  .

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -25,7 +25,8 @@ Description: The Server Density monitoring agent - ServerDensity CPU stats plugi
 
 Package: sd-agent-cockroachdb
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
 Description: The Server Density monitoring agent - CockroachDB plugin
  Collects CockroachDB metrics.
  .

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -25,7 +25,8 @@ Description: The Server Density monitoring agent - ServerDensity CPU stats plugi
 
 Package: sd-agent-cockroachdb
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
 Description: The Server Density monitoring agent - CockroachDB plugin
  Collects CockroachDB metrics.
  .

--- a/debian/sd-agent-cockroachdb.install
+++ b/debian/sd-agent-cockroachdb.install
@@ -1,4 +1,2 @@
 checks.d/cockroachdb.py usr/share/python/sd-agent/checks.d
 conf.d/cockroachdb.yaml.example etc/sd-agent/conf.d
-
-debian/build/lib/python2.7/site-packages/*prometheus_client*  usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+* Mon Mar 4 2019 Server Density <hello@serverdensity.com> 2.5.3-1
+- Update virtualenv packaging
 * Thu Jan 31 2019 Server Density <hello@serverdensity.com> 2.5.2-1
 - Added a 10s default timeout to the MySQL check.
 * Tue Dec 18 2018 Server Density <hello@serverdensity.com> 2.5.1-1

--- a/packaging/el/inc/install
+++ b/packaging/el/inc/install
@@ -36,3 +36,4 @@ rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/snakeb
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/supervisor*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/urllib3*
 rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/wheel*
+rm -Rf %{buildroot}/usr/share/python/sd-agent/lib/python2.7/site-packages/prometheus_client*

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -134,7 +134,7 @@ This package installs the ceph plugin.
 %package -n sd-agent-cockroachdb
 Summary: Server Density Monitoring Agent. cockroachdb plugin
 Group: System/Monitoring
-Requires: %{name} >= 2.2.2
+Requires: %{name} >= 2.2.5
 BuildArch: noarch
 
 %description -n sd-agent-cockroachdb
@@ -145,7 +145,6 @@ This package installs the cockroachdb plugin.
 %defattr(-,root,root,-)
 /usr/share/python/sd-agent/checks.d/cockroachdb.py
 %config /etc/sd-agent/conf.d/cockroachdb.yaml.example
-/usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/*prometheus_client*
 
 %package -n sd-agent-consul
 Summary: Server Density Monitoring Agent. consul plugin

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.5.2
+Version: 2.5.3


### PR DESCRIPTION
prometheus_client is now shipped with sd-agent and not sd-agent-cockroachdb.

Version has been bumped to v2.5.3