### PR TITLE
Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ notifications:
 jobs:
   include:
   - stage: CSV lint
-    install: gem install csvlint
+    install: go get github.com/Clever/csvlint/cmd/csvlint
     script: for metadata in `ls */metadata.csv`; do csvlint ${metadata}; done
-    rvm: 2.2.2
+    go: 1.10
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7

--- a/.travis/dockerfiles/el6_i386/Dockerfile
+++ b/.travis/dockerfiles/el6_i386/Dockerfile
@@ -19,7 +19,8 @@ RUN linux32 yum -y  --enablerepo=city-fan.org install yum-utils \
     ca-certificates
 RUN wget https://centos6.iuscommunity.org/ius-release.rpm
 RUN rpm -Uvh ius-release*.rpm
-RUN sed -i "s/\$basearch/i686/" /etc/yum.repos.d/ius-archive.repo
+RUN sed -i "s|https://repo.ius.io/archive/6/\$basearch/|https://dl.iuscommunity.org/pub/ius/archive/CentOS/6/i386/|" /etc/yum.repos.d/ius-archive.repo
+RUN rpm --import https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY
 RUN linux32 yum -y install python27 python27-devel --enablerepo=ius-archive --disablerepo=ius
 RUN wget https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
     rpm -Uvh pg*.rpm && \


### PR DESCRIPTION
Fixes: 
- Switched to a go implementation of csvlint ( https://github.com/Clever/csvlint/ ). The previous csvlint gem in use has dependency issues when installing.
- Updated the ius repository location to allow el6_i386 builds to complete.

@NassimHC please review and merge if happy. 