### PR TITLE
Enable arm builds for Debian & Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+os: linux
 language: python
 cache:
   directories:
@@ -18,8 +18,6 @@ branches:
   - "/.*/"
 services:
 - docker
-matrix:
-  fast_finish: true
 env:
   global:
   - CONCURRENCY=2

--- a/.travis/dockerfiles/bionic/Dockerfile
+++ b/.travis/dockerfiles/bionic/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist bionic $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist bionic $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/bionic/entrypoint.sh
+++ b/.travis/dockerfiles/bionic/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64 i386; do
+for ARCH in amd64 i386 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi

--- a/.travis/dockerfiles/buster/Dockerfile
+++ b/.travis/dockerfiles/buster/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/buster/entrypoint.sh
+++ b/.travis/dockerfiles/buster/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64 i386; do
+for ARCH in amd64 i386 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi

--- a/.travis/dockerfiles/stretch/Dockerfile
+++ b/.travis/dockerfiles/stretch/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist stretch $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist stretch $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/stretch/entrypoint.sh
+++ b/.travis/dockerfiles/stretch/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64 i386; do
+for ARCH in amd64 i386 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi

--- a/.travis/dockerfiles/trusty/Dockerfile
+++ b/.travis/dockerfiles/trusty/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist trusty $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist trusty $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh

--- a/.travis/dockerfiles/trusty/entrypoint.sh
+++ b/.travis/dockerfiles/trusty/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64 i386; do
+for ARCH in amd64 i386 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi

--- a/.travis/dockerfiles/xenial/Dockerfile
+++ b/.travis/dockerfiles/xenial/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64 i386; do pbuilder-dist xenial $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist xenial $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
-RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-classic" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
 RUN chmod +x /root/pbuilder-bootstrap.sh
 COPY ./entrypoint.sh /
 CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/xenial/entrypoint.sh
+++ b/.travis/dockerfiles/xenial/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64 i386; do
+for ARCH in amd64 i386 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi


### PR DESCRIPTION
Enables builds for arm64 arch type on Debian and Ubuntu OS's. 

Debian Jessie was skipped as it is EoL June 30th 2020. 

Also has some .travis.yaml fixes too, as build were erroring.