### PR TITLE
2.6.1 - Improve MySQL 8 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - PIP_CACHE=$HOME/.cache/pip
   - VOLATILE_DIR=/tmp
   - DD_CASHER_DIR=/tmp/casher
-  - AGENT_VERSION=2.6.0
+  - AGENT_VERSION=2.6.1
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el6=$CACHE_DIR/el6.tar.gz
   - CACHE_FILE_el6_i386=$CACHE_DIR/el6_i386.tar.gz

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent-core-plugins (2.6.1-1trusty0) trusty; urgency=medium
+
+  * Improve MySQL 8 compatibility
+
+ -- Server Density <hello@serverdensity.com>  Mon, 14 Apr 2020 10:00:00 +0100
+
 sd-agent-core-plugins (2.6.0-1trusty0) trusty; urgency=medium
 
   * Added mdadm plugin

--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd8
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd8
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,10 +843,30 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptgoraphy-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
  .
  See https://www.serverdensity.com/ for more information.
 
@@ -874,7 +883,7 @@ Description: The Server Density monitoring agent - jenkins plugin
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/distros/buster/control
+++ b/debian/distros/buster/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd8
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd8
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,9 +843,9 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
  .
  See https://www.serverdensity.com/ for more information.
@@ -871,10 +860,30 @@ Description: The Server Density monitoring agent - jenkins plugin
  .
  See https://www.serverdensity.com/ for more information.
 
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/distros/jessie/control
+++ b/debian/distros/jessie/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd4
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd4
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,10 +843,30 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
  .
  See https://www.serverdensity.com/ for more information.
 
@@ -874,7 +883,7 @@ Description: The Server Density monitoring agent - jenkins plugin
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd8
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd8
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,12 +843,33 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
  .
  See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
 
 Package: sd-agent-jenkins
 Architecture: all
@@ -874,7 +884,7 @@ Description: The Server Density monitoring agent - jenkins plugin
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd4
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd4
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,10 +843,30 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
  .
  See https://www.serverdensity.com/ for more information.
 
@@ -874,7 +883,7 @@ Description: The Server Density monitoring agent - jenkins plugin
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -235,17 +235,6 @@ Description: The Server Density monitoring agent - system-swap plugin
  .
  See https://www.serverdensity.com/ for more information.
 
-Package: sd-agent-ssh-check
-Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6
-Recommends: sd-agent-pyasn1-common
-Description: The Server Density monitoring agent - ssh_check plugin
- Monitor SSH connectivity and SFTP latency.
- .
- This package installs the ssh_check plugin.
- .
- See https://www.serverdensity.com/ for more information.
-
 Package: sd-agent-twemproxy
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
@@ -522,7 +511,7 @@ Description: The Server Density monitoring agent - cassandra cluster plugin usin
 
 Package: sd-agent-mysql
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0)
 Description: The Server Density monitoring agent - mysql plugin
  Collect performance schema metrics, query throughput, custom metrics, and more.
  .
@@ -714,7 +703,7 @@ Description: The Server Density monitoring agent - spark plugin
 
 Package: sd-agent-cacti
 Architecture: any
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.3.0), librrd4
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.0), librrd4
 Description: The Server Density monitoring agent - cacti plugin
  Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
  .
@@ -854,10 +843,30 @@ Description: The Server Density monitoring agent - storm plugin
 
 Package: sd-agent-mysql-common
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
-Breaks: sd-agent-mysql (<<2.2.0)
-Replaces: sd-agent-mysql (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.0)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
 Description: This package provides the python mysql module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi6, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
  .
  See https://www.serverdensity.com/ for more information.
 
@@ -874,7 +883,7 @@ Description: The Server Density monitoring agent - jenkins plugin
 Package: sd-agent-mdadm
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
-Description: The Server Density monitoring agent - Entropy plugin
+Description: The Server Density monitoring agent - Mdadm plugin
  Collects mdadm metrics.
  .
  This package installs the mdadm plugin.

--- a/debian/sd-agent-cryptography-common.install
+++ b/debian/sd-agent-cryptography-common.install
@@ -1,0 +1,6 @@
+debian/build/lib/python2.7/site-packages/cryptography*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/Crypto*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/enum*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/_cffi_backend.so  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/cffi* usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/pycparser* usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/debian/sd-agent-ssh-check.install
+++ b/debian/sd-agent-ssh-check.install
@@ -2,9 +2,3 @@ checks.d/ssh_check.py usr/share/python/sd-agent/checks.d
 conf.d/ssh_check.yaml.example etc/sd-agent/conf.d
 
 debian/build/lib/python2.7/site-packages/paramiko*  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/cryptography*  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/Crypto*  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/enum*  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/_cffi_backend.so  usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/cffi* usr/share/python/sd-agent/lib/python2.7/site-packages
-debian/build/lib/python2.7/site-packages/pycparser* usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/mysql/check.py
+++ b/mysql/check.py
@@ -833,7 +833,8 @@ class MySql(AgentCheck):
         try:
             with closing(db.cursor()) as cursor:
                 cursor.execute("SHOW BINARY LOGS;")
-                master_logs = dict(cursor.fetchall())
+                cursor_results = cursor.fetchall()
+                master_logs = {result[0]: result[1] for result in cursor_results}
 
                 binary_log_space = 0
                 for key, value in master_logs.iteritems():

--- a/mysql/requirements.txt
+++ b/mysql/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-pymysql==0.6.6
+pymysql==0.9.3

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+* Mon Apr 14 2020 Server Density <hello@serverdensity.com> 2.6.1-1
+- Improve MySQL 8 compatibility
 * Wed Mar 11 2020 Server Density <hello@serverdensity.com> 2.6.0-1
 - Adds mdadm plugin
 * Mon Mar 4 2019 Server Density <hello@serverdensity.com> 2.5.3-1

--- a/packaging/el/inc/subpackages
+++ b/packaging/el/inc/subpackages
@@ -377,8 +377,8 @@ do not reference it or depend on it in any way.
 Summary: Server Density Monitoring Agent. Common MySQL libs
 Group: System/Monitoring
 BuildArch: noarch
-Requires: %{name} >= 2.1.1
-Conflicts: sd-agent-mysql <= 2.2.0, sd-agent-cacti <= 2.2.0
+Requires: %{name} >= 2.1.1, sd-agent-cryptography-common
+Conflicts: sd-agent-mysql <= 2.6.0, sd-agent-cacti <= 2.6.0
 
 %description -n sd-agent-mysql-common
 %{longdescription}
@@ -924,7 +924,8 @@ This package installs the spark plugin.
 %package -n sd-agent-ssh-check
 Summary: Server Density Monitoring Agent. ssh_check plugin
 Group: System/Monitoring
-Requires: %{name} >= 2.2.0, sd-agent-pyasn1-common
+Requires: %{name} >= 2.2.0, sd-agent-pyasn1-common, sd-agent-cryptography-common
+Conflicts: sd-agent-ssh-check <= 2.6.0
 
 %description -n sd-agent-ssh-check
 %{longdescription}
@@ -935,6 +936,19 @@ This package installs the ssh_check plugin.
 /usr/share/python/sd-agent/checks.d/ssh_check.py
 %config /etc/sd-agent/conf.d/ssh_check.yaml.example
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/paramiko*
+
+%package -n sd-agent-cryptography-common
+Summary: Server Density Monitoring Agent. common crytopograhy libs
+Group: System/Monitoring
+Requires: %{name} >= 2.2.0
+Conflicts: sd-agent-ssh-check <= 2.6.0, sd-agent-mysql-common <= 2.6.0
+
+%description -n sd-agent-cryptography-common
+%{longdescription}
+This package installs common cryptography libs.
+
+%files -n sd-agent-cryptography-common
+%defattr(-,root,root,-)
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/cryptography*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/Crypto*
 /usr/share/python/sd-agent/lib/python%{__sd_python_version}/site-packages/enum*

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.6.0
+Version: 2.6.1


### PR DESCRIPTION
This PR brings in changes to improve the compatibility of MySQL 8 with the MySQL check. 
This required a small code change from upstream and a higher version of PyMySQL. PyMySQL also wants to make use of cryptography in some instances, so sd-agent-cryptography has been created which sd-agent-mysql and sd-agent-ssh-check depend on. 

@NassimHC please can you review and merge? 