### PR TITLE
Bump ntplib

### DIFF
--- a/.travis/build_containers.sh
+++ b/.travis/build_containers.sh
@@ -9,7 +9,6 @@ if [ ! -d "$CACHE_DIR" ]; then
 fi
 
 container_name=${RELEASE}
-echo -en "travis_fold:start:build_${container_name}_container\\r"
 cache_file_var="CACHE_FILE_${container_name}"
 docker_cache=${!cache_file_var}
 if [ ! -f "$docker_cache"  ]; then
@@ -21,4 +20,3 @@ if [ ! -f "$docker_cache"  ]; then
     cd ..
     docker save serverdensity:${container_name} | gzip > "$docker_cache"
 fi
-echo -en "travis_fold:end:build_${container_name}_container\\r"

--- a/.travis/build_packages.sh
+++ b/.travis/build_packages.sh
@@ -37,26 +37,20 @@ fi
 
 # Load the containers from cache
 
-echo -en "travis_fold:start:build_${CONTAINER}_container\\r"
 CACHE_FILE_VAR="CACHE_FILE_${CONTAINER}"
 DOCKER_CACHE=${!CACHE_FILE_VAR}
 echo "$DOCKER_CACHE"
 find "$CACHE_DIR"
 gunzip -c "$DOCKER_CACHE" | docker load;
-echo -en "travis_fold:end:build_${CONTAINER}_container\\r"
 
 
 # Run the containers, if container name is bionic run with --privileged
 echo "$CONTAINER"
 echo "$RELEASE"
 if [[ ${deb[*]} =~ "$RELEASE" ]]; then
-    echo -en "travis_fold:start:run_${CONTAINER}_container\\r"
     sudo docker run --volume="${TRAVIS_BUILD_DIR}":/sd-agent:rw --volume="${PACKAGES_DIR}":/packages:rw -e RELEASE="${RELEASE}" --privileged serverdensity:"${CONTAINER}"
-    echo -en "travis_fold:end:run_${CONTAINER}_container\\r"
 else
-    echo -en "travis_fold:start:run_${CONTAINER}_container\\r"
     sudo docker run --volume="${TRAVIS_BUILD_DIR}":/sd-agent-core-plugins:rw --volume="${PACKAGES_DIR}":/packages:rw -e sd_agent_version="${AGENT_VERSION}" serverdensity:"${CONTAINER}"
-    echo -en "travis_fold:end:run_${CONTAINER}_container\\r"
 fi
 
 sudo find "$PACKAGES_DIR"

--- a/.travis/dockerfiles/bionic/Dockerfile
+++ b/.travis/dockerfiles/bionic/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist bionic $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\

--- a/.travis/dockerfiles/buster/Dockerfile
+++ b/.travis/dockerfiles/buster/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist buster $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\

--- a/.travis/dockerfiles/el6/Dockerfile
+++ b/.travis/dockerfiles/el6/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y install \
     curl-devel \
     tar \
     symlinks \
-    epel-release
+    epel-release \
+    git
 RUN wget https://centos6.iuscommunity.org/ius-release.rpm && \
     rpm -Uvh ius-release*.rpm && \
     yum -y install python27 python27-devel

--- a/.travis/dockerfiles/el7/Dockerfile
+++ b/.travis/dockerfiles/el7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python-devel wget curl libyaml-devel curl-devel postgresql-devel tar postgresql-libs
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python-devel wget curl libyaml-devel curl-devel postgresql-devel tar postgresql-libs git
 
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
     ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \

--- a/.travis/dockerfiles/el8/Dockerfile
+++ b/.travis/dockerfiles/el8/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:8
 
 RUN yum -y install yum-utils
 RUN yum-config-manager --enable PowerTools
-RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2 git
 
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
     ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \

--- a/.travis/dockerfiles/jessie/Dockerfile
+++ b/.travis/dockerfiles/jessie/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386; do pbuilder-dist jessie $arch create --mirror "http://deb.debian.org/debian/" --othermirror "deb http://deb.debian.org/debian/ jessie main contrib non-free|deb-src http://deb.debian.org/debian/ jessie main contrib non-free|deb http://security.debian.org/ jessie/updates main contrib non-free|deb-src http://security.debian.org/ jessie/updates main contrib non-free"; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc

--- a/.travis/dockerfiles/stretch/Dockerfile
+++ b/.travis/dockerfiles/stretch/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist stretch $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\

--- a/.travis/dockerfiles/trusty/Dockerfile
+++ b/.travis/dockerfiles/trusty/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist trusty $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'USENETWORK=yes' >> /etc/pbuilderrc

--- a/.travis/dockerfiles/xenial/Dockerfile
+++ b/.travis/dockerfiles/xenial/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 WORKDIR /root
-RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support git
 RUN echo 'for arch in amd64 i386 arm64; do pbuilder-dist xenial $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-classic" \n\

--- a/debian/distros/bionic/control
+++ b/debian/distros/bionic/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/debian/distros/buster/control
+++ b/debian/distros/buster/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/debian/distros/jessie/control
+++ b/debian/distros/jessie/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/debian/distros/stretch/control
+++ b/debian/distros/stretch/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/debian/distros/trusty/control
+++ b/debian/distros/trusty/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/debian/distros/xenial/control
+++ b/debian/distros/xenial/control
@@ -5,7 +5,7 @@ Maintainer: Server Density Developers <hello@serverdensity.com>
 Build-Depends: debhelper (>= 9), python (>= 2.7.0), python-setuptools,
   python-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
   symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
-  build-essential
+  build-essential, git
 Standards-Version: 3.9.5
 Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
 Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git

--- a/ntp/requirements.txt
+++ b/ntp/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-ntplib==0.3.3
+ntplib==0.3.4

--- a/ntp/requirements.txt
+++ b/ntp/requirements.txt
@@ -1,2 +1,2 @@
 # integration pip requirements
-ntplib==0.3.4
+git+https://github.com/cf-natali/ntplib.git@master


### PR DESCRIPTION
This 'bumps' the ntplib dep to 0.3.4, however, in order to avoid binary usage I had to switch to using git in requirements.txt. 

Using master isn't an issue as ntplib is shipped in the sd-agent package as the core agent requires it, meaning the pinned version there is the version that is in use. However we need ntplib to be installed for builds to complete successfully.

@NassimHC please review and merge if happy. 