### PR TITLE
Fix get pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ env:
   - DD_CASHER_DIR=/tmp/casher
   - AGENT_VERSION=2.6.3
   - CACHE_DIR=$HOME/.cache
-  - CACHE_FILE_el6=$CACHE_DIR/el6.tar.gz
-  - CACHE_FILE_el6_i386=$CACHE_DIR/el6_i386.tar.gz
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
   - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
   - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
@@ -83,14 +81,6 @@ jobs:
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
     env: RELEASE=trusty
-  - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
-    env: RELEASE=el6
-  - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
-    env: RELEASE=el6_i386
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
@@ -186,34 +176,6 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=trusty
-    python: 2.7
-    deploy:
-    - provider: gcs
-      access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
-      secret_access_key:
-        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
-      bucket: sd-agent-packages
-      acl: public-read
-      local_dir: "/serverdensity"
-      on:
-        all_branches: true
-  - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
-    env: RELEASE=el6
-    python: 2.7
-    deploy:
-    - provider: gcs
-      access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
-      secret_access_key:
-        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
-      bucket: sd-agent-packages
-      acl: public-read
-      local_dir: "/serverdensity"
-      on:
-        all_branches: true
-  - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
-    env: RELEASE=el6_i386
     python: 2.7
     deploy:
     - provider: gcs

--- a/.travis/build_packages.sh
+++ b/.travis/build_packages.sh
@@ -13,6 +13,9 @@ echo "$CONTAINER"
 set -ev
 
 rvm install 2.1.5
+rvm --default use 2.1.5
+ruby -v
+rvm list
 bundle install
 rake copy_checks
 

--- a/.travis/build_packages.sh
+++ b/.travis/build_packages.sh
@@ -17,7 +17,7 @@ rvm --default use 2.1.5
 ruby -v
 rvm list
 bundle install
-rake copy_checks
+bundle exec rake copy_checks
 
 if [ -f "${TRAVIS_BUILD_DIR}/config.py" ]; then
    AGENT_VERSION=$(awk -F'"' '/^AGENT_VERSION/ {print $2}' ${TRAVIS_BUILD_DIR}/config.py)

--- a/.travis/dockerfiles/el8/Dockerfile
+++ b/.travis/dockerfiles/el8/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 RUN yum -y install yum-utils
-RUN yum-config-manager --enable PowerTools
+RUN yum-config-manager --enable powertools
 RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2 git
 
 RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/serverdensity/sd-agent-core-plugins.svg?branch=master)](https://travis-ci.org/serverdensity/sd-agent-core-plugins)
+[![Build Status](https://travis-ci.com/serverdensity/sd-agent-core-plugins.svg?branch=master)](https://travis-ci.com/serverdensity/sd-agent-core-plugins)
 <!---[![Build status](https://ci.appveyor.com/api/projects/status/?svg=true)](https://ci.appveyor.com/project/)-->
 # Server Density Agent Core Plugins
 

--- a/debian/rules
+++ b/debian/rules
@@ -103,6 +103,6 @@ define create_venv
 	python virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
 	curl -LO https://bootstrap.pypa.io/ez_setup.py
 	$(BUILD_DIR)/bin/python ez_setup.py --version="44.1.1"
-	curl -LO https://bootstrap.pypa.io/get-pip.py
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 	$(BUILD_DIR)/bin/python get-pip.py
 endef

--- a/gunicorn/ci/gunicorn.rake
+++ b/gunicorn/ci/gunicorn.rake
@@ -25,7 +25,7 @@ namespace :ci do
       `python #{gunicorn_rootdir}/venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools #{gunicorn_rootdir}/venv/`
       `wget -q -O #{gunicorn_rootdir}/venv/ez_setup.py https://bootstrap.pypa.io/ez_setup.py`
       `#{gunicorn_rootdir}/venv/bin/python #{gunicorn_rootdir}/venv/ez_setup.py`
-      `wget -q -O #{gunicorn_rootdir}/venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`
+      `wget -q -O #{gunicorn_rootdir}/venv/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py`
       `#{gunicorn_rootdir}/venv/bin/python #{gunicorn_rootdir}/venv/get-pip.py`
       `#{gunicorn_rootdir}/venv/bin/pip install gunicorn==#{gunicorn_version} gevent setproctitle`
       `#{gunicorn_rootdir}/venv/bin/pip install setproctitle`

--- a/packaging/el/SPECS/sd-agent-core-plugins-el6.spec
+++ b/packaging/el/SPECS/sd-agent-core-plugins-el6.spec
@@ -34,7 +34,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2.7 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent-core-plugins

--- a/packaging/el/SPECS/sd-agent-core-plugins-el7.spec
+++ b/packaging/el/SPECS/sd-agent-core-plugins-el7.spec
@@ -34,7 +34,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent-core-plugins

--- a/packaging/el/SPECS/sd-agent-core-plugins-el8.spec
+++ b/packaging/el/SPECS/sd-agent-core-plugins-el8.spec
@@ -34,7 +34,7 @@ curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
 python2 virtualenv.py --no-site-packages --no-pip --no-setuptools %{__venv}
 curl -LO https://bootstrap.pypa.io/ez_setup.py
 %{__venv}/bin/python ez_setup.py --version="44.1.1"
-curl -LO https://bootstrap.pypa.io/get-pip.py
+curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
 %{__venv}/bin/python get-pip.py
 
 %setup -qn sd-agent-core-plugins


### PR DESCRIPTION
This PR: 
* Fixes get-pip URL for 2.7.
* Updates el8 powertools repository name.
* Removes el6 from travis config, but has not removed the files.
* Ensures ruby 2.1.5 is used. 
* Updates travis-ci badge to .com, as the repository has been migrated.

Builds have been successful on this branch and the agent has been tested to ensure that this did not inadvertently break any functionality