### PR TITLE
Version bump 2.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - PIP_CACHE=$HOME/.cache/pip
   - VOLATILE_DIR=/tmp
   - DD_CASHER_DIR=/tmp/casher
-  - AGENT_VERSION=2.6.3
+  - AGENT_VERSION=2.6.4
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
   - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ env:
   - CACHE_FILE_focal=$CACHE_DIR/focal.tar.gz
   - CACHE_FILE_jessie=$CACHE_DIR/jessie.tar.gz
   - CACHE_FILE_stretch=$CACHE_DIR/stretch.tar.gz
-  - CACHE_FILE_trusty=$CACHE_DIR/trusty.tar.gz
   - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
   - conf_dir=conf.d
   - checks_dir=checks.d
@@ -77,10 +76,6 @@ jobs:
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
     env: RELEASE=stretch
-  - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
-    env: RELEASE=trusty
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
@@ -162,20 +157,6 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=stretch
-    python: 2.7
-    deploy:
-    - provider: gcs
-      access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
-      secret_access_key:
-        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
-      bucket: sd-agent-packages
-      acl: public-read
-      local_dir: "/serverdensity"
-      on:
-        all_branches: true
-  - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
-    env: RELEASE=trusty
     python: 2.7
     deploy:
     - provider: gcs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,13 @@
 sd-agent-core-plugins (2.6.3-1trusty0) trusty; urgency=medium
 
+  * Varnish: fix parsing of varnishstat 6.5 JSON output
+  * Mdadm: fix parsing to ensure RAID0 disks are captured
+  * Mdadm: add system.mdadm.in_use_devices metric
+
+ -- Server Density <hello@serverdensity.com>  Mon, 19 Apr 2021 10:00:00 +0100
+
+sd-agent-core-plugins (2.6.3-1trusty0) trusty; urgency=medium
+
   * Security Update: Updates python httplib2 to address CVE-2020-11078.
 
  -- Server Density <hello@serverdensity.com>  Mon, 1 Jun 2020 10:00:00 +0100

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,8 @@
 %changelog
+* Mon Apr 19 2021 Server Density <hello@serverdensity.com> 2.6.4-1
+- Varnish: fix parsing of varnishstat 6.5 JSON output
+- Mdadm: fix parsing to ensure RAID0 disks are captured
+- Mdadm: add system.mdadm.in_use_devices metric
 * Mon Jun 1 2020 Server Density <hello@serverdensity.com> 2.6.3-1
 - Security Update: Updates python httplib2 to address CVE-2020-11078.
 * Tue May 5 2020 Server Density <hello@serverdensity.com> 2.6.2-1

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.6.3
+Version: 2.6.4


### PR DESCRIPTION
* Bumps version to 2.6.4 and updates changelogs for mdadm and varnish plugin fixes. 
* Removes trusty from builds. 