### PR TITLE
[mdadm] check for presence of raid_disks / add system.mdadm.in_use_devices

### DIFF
--- a/mdadm/CHANGELOG.md
+++ b/mdadm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG - mdadm
 
+1.1.0 / 2021-04-16
+==================
+
+### Changes
+
+* [BUGFIX] Check for presence of raid_disks before attempting to determine degraded status
+* [FEATURE] Add `system.mdadm.device_count` metric
+
 1.0.0 / 2020-03-11
 ==================
 

--- a/mdadm/check.py
+++ b/mdadm/check.py
@@ -1,7 +1,7 @@
 """
   Server Density Plugin
   Mdadm Check
-  Version: 1.0.0
+  Version: 1.1.0
 """
 
 import json

--- a/mdadm/check.py
+++ b/mdadm/check.py
@@ -34,6 +34,8 @@ class Mdadm(AgentCheck):
             self.log.debug('mdstat.parse returned: {}'.format(data))
             self.gauge("system.mdadm.unused_devices",
                        len(data['unused_devices']))
+            self.gauge("system.mdadm.in_use_devices",
+                       len(data['devices']))
             for device in data['devices']:
                 tags = []
                 try:

--- a/mdadm/check.py
+++ b/mdadm/check.py
@@ -39,9 +39,12 @@ class Mdadm(AgentCheck):
                 try:
                     tags.append("device:{}".format(device))
                     status_dict = data['devices'][device]['status']
-                    degraded = status_dict['raid_disks'] != \
-                        status_dict['non_degraded_disks']
-                    self.gauge("system.mdadm.degraded", int(degraded), tags)
+                    if status_dict.get('raid_disks'):
+                        # These keys are not present for RAID0 devices
+                        degraded = status_dict['raid_disks'] != \
+                            status_dict['non_degraded_disks']
+                        self.gauge("system.mdadm.degraded",
+                                   int(degraded), tags)
                     self.gauge("system.mdadm.read_only",
                                int(data['devices'][device]['read_only']), tags)
                     self.gauge("system.mdadm.active",

--- a/mdadm/metadata.csv
+++ b/mdadm/metadata.csv
@@ -1,12 +1,13 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.mdadm.blocks,gauge,,,,The useable size of the array in blocks,1,mdadm,mdadm blocks
-system.mdadm.degraded,gauge,,,,The degraded state of the device,1,mdadm,mdadm degraded 
+system.mdadm.degraded,gauge,,,,The degraded state of the device,1,mdadm,mdadm degraded
 system.mdadm.non_degraded_disks,gauge,,,,A count of non degraded disks,1,mdadm,mdadm non degraded disks
 system.mdadm.raid_disks,gauge,,,,A count of raid disks,1,mdadm,mdadm raid disks
-system.mdadm.read_only,gauge,,,,The read only state ,1,mdadm,mdadm read only 
+system.mdadm.read_only,gauge,,,,The read only state ,1,mdadm,mdadm read only
 system.mdadm.active,gauge,,,,The active state of the array. ,1,mdadm,mdadm active
-system.mdadm.disk.faulty,gauge,,,,The faulty state of the disk,1,mdadm,mdadm disk faulty 
+system.mdadm.disk.faulty,gauge,,,,The faulty state of the disk,1,mdadm,mdadm disk faulty
 system.mdadm.disk.number,gauge,,,,The disk number,1,mdadm,mdadm disk number
 system.mdadm.disk.replacement,gauge,,,,The replacement state of the disk,1,mdadm,mdadm disk replacement
 system.mdadm.disk.spare,gauge,,,,The spare state of the disk,1,mdadm,mdadm disk spare
 system.mdadm.disk.write_mostly,gauge,,,,The write mostly state of the disk ,1,mdadm,madam disk write mostly
+system.mdadm.in_use_devices,gauge,,,,The number of devices in use,1,mdadm,mdadm devices in use

--- a/mdadm/metadata.csv
+++ b/mdadm/metadata.csv
@@ -9,5 +9,6 @@ system.mdadm.disk.faulty,gauge,,,,The faulty state of the disk,1,mdadm,mdadm dis
 system.mdadm.disk.number,gauge,,,,The disk number,1,mdadm,mdadm disk number
 system.mdadm.disk.replacement,gauge,,,,The replacement state of the disk,1,mdadm,mdadm disk replacement
 system.mdadm.disk.spare,gauge,,,,The spare state of the disk,1,mdadm,mdadm disk spare
-system.mdadm.disk.write_mostly,gauge,,,,The write mostly state of the disk ,1,mdadm,madam disk write mostly
+system.mdadm.disk.write_mostly,gauge,,,,The write mostly state of the disk ,1,mdadm,mdadm disk write mostly
 system.mdadm.in_use_devices,gauge,,,,The number of devices in use,1,mdadm,mdadm devices in use
+system.mdadm.unused_devices,gauge,,,,The number of unused devices,1,mdadm,mdadm unused devices


### PR DESCRIPTION
Resolves a user reported issue with the mdadm plugin where RAID0 devices would cause the plugin to fail due to the `raid_disks` key not being present. As the `raid_disks` value is used to determine the degraded status a `system.mdadm.in_use_devices` metric was added so users can be notified if a RAID device is not present. 

Also cleans up some of the metadata. 