### PR TITLE
[varnish] fix parsing of varnishstat 6.5 JSON output 

### DIFF
--- a/varnish/check.py
+++ b/varnish/check.py
@@ -208,6 +208,8 @@ class Varnish(AgentCheck):
             p.Parse(output, True)
         elif varnishstat_format == "json":
             json_output = json.loads(output)
+            if "counters" in json_output:
+                json_output = json_output["counters"]
             for name, metric in json_output.iteritems():
                 if not isinstance(metric, dict): # skip 'timestamp' field
                     continue

--- a/varnish/ci/fixtures/stats_output_json_6.5
+++ b/varnish/ci/fixtures/stats_output_json_6.5
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "timestamp": "2020-10-06T20:43:18",
+  "counters": {
+    "MGT.uptime": {
+      "description": "Management process uptime",
+      "flag": "c",
+      "format": "d",
+      "value": 2544
+    },
+    "MGT.child_start": {
+      "description": "Child process started",
+      "flag": "c",
+      "format": "i",
+      "value": 1
+    },
+    "MGT.child_exit": {
+      "description": "Child process normal exit",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    }
+  }
+}
+


### PR DESCRIPTION
The JSON structure returned by `varnishstat -j` changed in version 6.5.
Notably, all counters have been moved under the "counters" key.

https://github.com/varnishcache/varnish-cache/blob/6.5/doc/changes.rst#varnish-cache-650-2020-09-15

----
Pulls in a commit from upstream that ensures that varnishstat 6.5 metrics are parsed correctly.