### PR TITLE
Update version number to 2.6.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sd-agent-core-plugins (2.6.3-1trusty0) trusty; urgency=medium
+sd-agent-core-plugins (2.6.4-1trusty0) trusty; urgency=medium
 
   * Varnish: fix parsing of varnishstat 6.5 JSON output
   * Mdadm: fix parsing to ensure RAID0 disks are captured


### PR DESCRIPTION
Updates the version number for debian builds to 2.6.4, which was missed in the previous PR.