### PR TITLE
Enable Focal aarch64/arm64 builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
     env: RELEASE=focal
+    dist: focal
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
     python: 2.7
@@ -115,6 +116,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=focal
+    dist: focal
     python: 2.7
     deploy:
     - provider: gcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
   - checks_dir=checks.d
 before_script:
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends
-  install binfmt-support qemu-user-static createrepo reprepro; fi
+  install binfmt-support qemu-user-static; fi
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-language: python
 cache:
   directories:
   - "$HOME/.cache/pip"
@@ -7,8 +6,6 @@ cache:
   - vendor/cache
   - "$CACHE_DIR"
   timeout: 1000
-python:
-  - "2.7"
 
 git:
   depth: 3
@@ -43,6 +40,7 @@ before_script:
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends
   install binfmt-support qemu-user-static; fi
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi
+install: bundle install
 notifications:
   slack:
     secure: EIK5M4WH0/ZnwgCyd6T4801Ll9g9pQuxmkL5PVCCzUHeT2ouwxFepEA/2olb74DYUc1DiDbhlKyevxZVw9l6G2vwZY670N9ZAhbivyDjK6hOduIt8+YicJNtFs3PzilRpu9yPrpDFlrOeuT8MT1TMP8xTCfvDa6WDic2Nfen4L0=
@@ -54,41 +52,41 @@ jobs:
     go: 1.10
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=bionic
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=buster
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=focal
     dist: focal
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=jessie
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=xenial
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=stretch
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=el7
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
-    python: 2.7
+    rvm: 2.5
     env: RELEASE=el8
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=bionic
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -102,7 +100,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=buster
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -117,7 +115,7 @@ jobs:
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=focal
     dist: focal
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -131,7 +129,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=jessie
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -145,7 +143,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=xenial
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -159,7 +157,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=stretch
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -173,7 +171,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=el7
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
@@ -187,7 +185,7 @@ jobs:
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=el8
-    python: 2.7
+    rvm: 2.5
     deploy:
     - provider: gcs
       access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
   - conf_dir=conf.d
   - checks_dir=checks.d
 before_script:
+- if [ "${TRAVIS_DIST}" == "focal" ]; then sudo add-apt-repository ppa:canonical-server/server-backports -y; fi
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then sudo apt-get --yes --no-install-recommends
   install binfmt-support qemu-user-static; fi
 - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register; fi

--- a/.travis/build_packages.sh
+++ b/.travis/build_packages.sh
@@ -12,10 +12,6 @@ CONTAINER="$RELEASE"
 echo "$CONTAINER"
 set -ev
 
-rvm install 2.1.5
-rvm --default use 2.1.5
-ruby -v
-rvm list
 bundle install
 bundle exec rake copy_checks
 

--- a/.travis/dockerfiles/focal/Dockerfile
+++ b/.travis/dockerfiles/focal/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 WORKDIR /root
 RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
-RUN echo 'for arch in amd64; do pbuilder-dist focal $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN echo 'for arch in amd64 arm64; do pbuilder-dist focal $arch create; done' > /root/pbuilder-bootstrap.sh
 RUN apt-get install --reinstall qemu-user-static
 RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
 USENETWORK=yes \n\

--- a/.travis/dockerfiles/focal/entrypoint.sh
+++ b/.travis/dockerfiles/focal/entrypoint.sh
@@ -14,7 +14,7 @@ sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
 sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
 sudo dpkg-source -b /sd-agent
 
-for ARCH in amd64; do
+for ARCH in amd64 arm64; do
     if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
         sudo mkdir /packages/${DISTRO}/${RELEASE}
     fi


### PR DESCRIPTION
This PR updates the build scripts to enable aarch64/arm64 builds for Ubuntu Focal per customer requests. 

A couple of things to note: 
* The Focal container build and package build stages now run on a Focal host 
* The error `semop(1): encountered an error: Function not implemented` was seen when running the builds and prevented them from completing. To workaround this the `ppa:canonical-server/server-backports`  is added to Focal hosts which allows qemu-user-static backported from Groovy to be installed which resolves this error. [0]
* We were previously using ruby 2.1.5, however Focal does not have the correct dependencies available for this, so I bumped the Ruby version to 2.5 for everything instead of working around the dependency issue with 2.1.5 and Focal. This also allowed the rvm commands to be removed from `.travis/build_packages.sh`
  * This bump was completed via travis.yaml. The build containers and build packages stages are now Ruby, and the tests stage is go 1.10. 
  * Ruby is not really made use of in the builds for sd-agent, however it is a requirement for sd-agent-core-plugins. I opted for this change in sd-agent too in order to maintain as much parity as possible between the builds. 
* Createrepo and reprepro were removed as they are not used in the build and createrepo is not available on Focal+ causing the builds to fail. 

[0] https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1895456