### PR TITLE
Add El ARM Packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
   - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz
   - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
+  - CACHE_FILE_el8_arm=$CACHE_DIR/el8_arm.tar.gz
   - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
   - CACHE_FILE_bullseye=$CACHE_DIR/bullseye.tar.gz
   - CACHE_FILE_buster=$CACHE_DIR/buster.tar.gz
@@ -95,6 +96,11 @@ jobs:
     script: travis_retry ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el8
+  - stage: build containers
+    script: travis_retry ./.travis/build_containers.sh
+    rvm: 2.5
+    env: RELEASE=el8_arm
+    dist: focal
   - stage: build packages
     script: travis_retry ./.travis/build_packages.sh
     env: RELEASE=bionic
@@ -235,6 +241,21 @@ jobs:
       bucket: sd-agent-packages
       acl: public-read
       local_dir: "/serverdensity"
+      on:
+        all_branches: true
+  - stage: build packages
+    script: travis_retry ./.travis/build_packages.sh
+    env: RELEASE=el8_arm
+    dist: focal
+    rvm: 2.5
+    deploy:
+    - provider: gcs
+      access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
+      secret_access_key:
+        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
+      bucket: "sd-agent-packages"
+      acl: public-read
+      local_dir: /serverdensity
       on:
         all_branches: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - AGENT_VERSION=2.6.5
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
+  - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz
   - CACHE_FILE_el8=$CACHE_DIR/el8.tar.gz
   - CACHE_FILE_bionic=$CACHE_DIR/bionic.tar.gz
   - CACHE_FILE_bullseye=$CACHE_DIR/bullseye.tar.gz
@@ -85,6 +86,11 @@ jobs:
     script: travis_retry ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el7
+  - stage: build containers
+    script: travis_retry ./.travis/build_containers.sh
+    rvm: 2.5
+    env: RELEASE=el7_arm
+    dist: focal
   - stage: build containers
     script: travis_retry ./.travis/build_containers.sh
     rvm: 2.5
@@ -200,6 +206,21 @@ jobs:
       bucket: sd-agent-packages
       acl: public-read
       local_dir: "/serverdensity"
+      on:
+        all_branches: true
+  - stage: build packages
+    script: travis_retry ./.travis/build_packages.sh
+    env: RELEASE=el7_arm
+    dist: focal
+    rvm: 2.5
+    deploy:
+    - provider: gcs
+      access_key_id: "GOOGQSTXHRV5ODGTXK2GT4U4"
+      secret_access_key:
+        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
+      bucket: "sd-agent-packages"
+      acl: public-read
+      local_dir: /serverdensity
       on:
         all_branches: true
   - stage: build packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,54 +55,54 @@ jobs:
     script: for metadata in `ls */metadata.csv`; do csvlint ${metadata}; done
     go: 1.10
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=bionic
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=bullseye
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=buster
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=focal
     dist: focal
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=jessie
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=xenial
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=stretch
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el7
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el7_arm
     dist: focal
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el8
   - stage: build containers
-    script: travis_retry ./.travis/build_containers.sh
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=el8_arm
     dist: focal
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=bionic
     rvm: 2.5
     deploy:
@@ -116,7 +116,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=bullseye
     rvm: 2.5
     deploy:
@@ -130,7 +130,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=buster
     rvm: 2.5
     deploy:
@@ -144,7 +144,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=focal
     dist: focal
     rvm: 2.5
@@ -159,7 +159,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=jessie
     rvm: 2.5
     deploy:
@@ -173,7 +173,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=xenial
     rvm: 2.5
     deploy:
@@ -187,7 +187,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=stretch
     rvm: 2.5
     deploy:
@@ -201,7 +201,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=el7
     rvm: 2.5
     deploy:
@@ -215,7 +215,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=el7_arm
     dist: focal
     rvm: 2.5
@@ -230,7 +230,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=el8
     rvm: 2.5
     deploy:
@@ -244,7 +244,7 @@ jobs:
       on:
         all_branches: true
   - stage: build packages
-    script: travis_retry ./.travis/build_packages.sh
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=el8_arm
     dist: focal
     rvm: 2.5

--- a/.travis/dockerfiles/el7_arm/Dockerfile
+++ b/.travis/dockerfiles/el7_arm/Dockerfile
@@ -1,0 +1,9 @@
+FROM arm64v8/centos:7
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python-devel wget curl libyaml-devel curl-devel postgresql-devel tar postgresql-libs git
+
+RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
+    ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \
+    ( grep -q :1000: /etc/group || groupadd -g 1000 ubuntu_group ) && \
+    ( grep -q :1000: /etc/passwd || useradd  -u 1000 -g 1000 ubuntu_user )
+COPY ./entrypoint.sh /
+CMD ["/entrypoint.sh"]

--- a/.travis/dockerfiles/el7_arm/entrypoint.sh
+++ b/.travis/dockerfiles/el7_arm/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -xe
+cat > $HOME/.rpmmacros << EOF_MACROS
+%_topdir /root/el
+%_tmppath %{_topdir}/tmp
+%_signature gpg
+%_gpg_name hello@serverdensity.com
+%_gpg_path ~/.gnupg
+EOF_MACROS
+mkdir /root/el
+cd /root/el
+for dir in SOURCES BUILD RPMS SRPMS; do
+    [ -d $dir ] || mkdir $dir
+done
+#sd_agent_version=$(awk -F'"' '/^AGENT_VERSION/ {print $2}' /sd-agent/config.py)
+tar -czf /root/el/SOURCES/sd-agent-core-plugins-${sd_agent_version}.tar.gz /sd-agent-core-plugins
+cp -a /sd-agent-core-plugins/packaging/el/{SPECS,inc,description,pgbouncer-centos7} /root/el
+cd /root/el
+chown -R `id -u`:`id -g` /root/el
+function build {
+    rpmdir=/root/build/result/$1
+    yum-builddep -y SPECS/sd-agent-core-plugins-$1.spec
+    rpmbuild -ba SPECS/sd-agent-core-plugins-$1.spec && \
+    (test -d $rpmdir || mkdir -p $rpmdir) && cp -a /root/el/RPMS/* $rpmdir
+}
+build "el7"
+if [ ! -d /packages/el ]; then
+    mkdir /packages/el
+fi
+
+if [ ! -d /packages/el/7 ]; then
+    mkdir /packages/el/7
+fi
+
+if [ ! -d /packages/src ]; then
+    mkdir /packages/src
+fi
+rm -rf /root/el/RPMS/*/sd-agent-${sd_agent_version}*.rpm
+cp -r /root/el/RPMS/* /packages/el/7
+cp -r /root/el/SRPMS/* /packages/src

--- a/.travis/dockerfiles/el8/Dockerfile
+++ b/.travis/dockerfiles/el8/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum -y install yum-utils
 RUN yum-config-manager --enable powertools
 RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2 git

--- a/.travis/dockerfiles/el8_arm/Dockerfile
+++ b/.travis/dockerfiles/el8_arm/Dockerfile
@@ -1,0 +1,15 @@
+FROM arm64v8/centos:8
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* &&\
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+RUN yum -y install yum-utils
+RUN yum-config-manager --enable powertools
+RUN yum -y install yum-utils rpm-build redhat-rpm-config make gcc python2-devel wget curl curl-devel postgresql-devel tar python2 git
+
+RUN ( grep -q :20: /etc/group || groupadd -g 20 osx_staff ) && \
+    ( grep -q :501: /etc/passwd || useradd -u 501 -g 20 osx_user ) && \
+    ( grep -q :1000: /etc/group || groupadd -g 1000 ubuntu_group ) && \
+    ( grep -q :1000: /etc/passwd || useradd  -u 1000 -g 1000 ubuntu_user )
+COPY ./entrypoint.sh /
+CMD ["/entrypoint.sh"]

--- a/.travis/dockerfiles/el8_arm/entrypoint.sh
+++ b/.travis/dockerfiles/el8_arm/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -xe
+cat > $HOME/.rpmmacros << EOF_MACROS
+%_topdir /root/el
+%_tmppath %{_topdir}/tmp
+%_signature gpg
+%_gpg_name hello@serverdensity.com
+%_gpg_path ~/.gnupg
+EOF_MACROS
+mkdir /root/el
+cd /root/el
+for dir in SOURCES BUILD RPMS SRPMS; do
+    [ -d $dir ] || mkdir $dir
+done
+#sd_agent_version=$(awk -F'"' '/^AGENT_VERSION/ {print $2}' /sd-agent/config.py)
+tar -czf /root/el/SOURCES/sd-agent-core-plugins-${sd_agent_version}.tar.gz /sd-agent-core-plugins
+cp -a /sd-agent-core-plugins/packaging/el/{SPECS,inc,description,pgbouncer-centos8} /root/el
+cd /root/el
+chown -R `id -u`:`id -g` /root/el
+function build {
+    rpmdir=/root/build/result/$1
+    yum-builddep -y SPECS/sd-agent-core-plugins-$1.spec
+    rpmbuild -ba SPECS/sd-agent-core-plugins-$1.spec  --define="_build_id_links none" && \
+    (test -d $rpmdir || mkdir -p $rpmdir) && cp -a /root/el/RPMS/* $rpmdir
+}
+build "el8"
+if [ ! -d /packages/el ]; then
+    mkdir /packages/el
+fi
+
+if [ ! -d /packages/el/8 ]; then
+    mkdir /packages/el/8
+fi
+
+if [ ! -d /packages/src ]; then
+    mkdir /packages/src
+fi
+rm -rf /root/el/RPMS/*/sd-agent-${sd_agent_version}*.rpm
+cp -r /root/el/RPMS/* /packages/el/8
+cp -r /root/el/SRPMS/* /packages/src

--- a/packaging/el/SPECS/sd-agent-core-plugins-el7.spec
+++ b/packaging/el/SPECS/sd-agent-core-plugins-el7.spec
@@ -13,7 +13,6 @@
 
 Summary: Server Density Monitoring Agent
 Name: sd-agent
-BuildArch: x86_64 i386
 %include %{_topdir}/inc/version
 %include %{_topdir}/inc/release
 Requires: python >= 2.7, sysstat, libyaml

--- a/packaging/el/SPECS/sd-agent-core-plugins-el8.spec
+++ b/packaging/el/SPECS/sd-agent-core-plugins-el8.spec
@@ -13,7 +13,6 @@
 
 Summary: Server Density Monitoring Agent
 Name: sd-agent
-BuildArch: x86_64 i386
 %include %{_topdir}/inc/version
 %include %{_topdir}/inc/release
 Requires: python2 >= 2.7, sysstat, libyaml


### PR DESCRIPTION
This PR:

* Fixes an error in the el8 build containers.
* Adds packaging for aarch64 for el7/8
* Removes the BuildArch from the el SPEC files as the build arch is implied from the build container's arch.
* Adds travis_wait to all script commands as the el containers do not output anything for over 10mins (causing the build to be deemed failed) despite still running.