### PR TITLE
Ensure process alerts trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - PIP_CACHE=$HOME/.cache/pip
   - VOLATILE_DIR=/tmp
   - DD_CASHER_DIR=/tmp/casher
-  - AGENT_VERSION=2.6.5
+  - AGENT_VERSION=2.6.6
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
   - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent-core-plugins (2.6.6-1trusty0) trusty; urgency=medium
+
+  * Process: Fix metric tagging ensuring alerts trigger
+
+ -- Server Density <hello@serverdensity.com>  Wed, 13 Mar 2022 10:00:00 +0100
+
 sd-agent-core-plugins (2.6.5-1trusty0) trusty; urgency=medium
 
   * MySQL: fix parsing of replication data

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+* Wed Mar 30 2022 Server Density <hello@serverdensity.com> 2.6.6-1
+- Process: Fix metric tagging ensuring alerts trigger
 * Mon Jan 10 2022 Server Density <hello@serverdensity.com> 2.6.5-1
 - MySQL: Fix parsing of replication data
 * Mon Apr 19 2021 Server Density <hello@serverdensity.com> 2.6.4-1

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.6.5
+Version: 2.6.6

--- a/process/check.py
+++ b/process/check.py
@@ -386,8 +386,7 @@ class ProcessCheck(AgentCheck):
 
         proc_state = self.get_process_state(name, pids)
 
-        # FIXME 6.x remove the `name` tag
-        tags.extend(['process_name:%s' % name, name])
+        tags.extend(['process_name:%s' % name])
 
         self.log.debug('ProcessCheck: process %s analysed', name)
         self.gauge('system.processes.instances', len(pids), tags=tags)

--- a/process/check.py
+++ b/process/check.py
@@ -386,7 +386,7 @@ class ProcessCheck(AgentCheck):
 
         proc_state = self.get_process_state(name, pids)
 
-        tags.extend(['process_name:%s' % name])
+        tags.extend(['process_name:%s' % name, 'process:%s' % name])
 
         self.log.debug('ProcessCheck: process %s analysed', name)
         self.gauge('system.processes.instances', len(pids), tags=tags)


### PR DESCRIPTION
Adds `process:$process` tag to ensure that process alerts trigger.

Bumps version to 2.6.5 for release.