### PR TITLE
Add Jammy/Ubuntu 22 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
   - CACHE_FILE_bullseye=$CACHE_DIR/bullseye.tar.gz
   - CACHE_FILE_buster=$CACHE_DIR/buster.tar.gz
   - CACHE_FILE_focal=$CACHE_DIR/focal.tar.gz
+  - CACHE_FILE_jammy=$CACHE_DIR/jammy.tar.gz
   - CACHE_FILE_jessie=$CACHE_DIR/jessie.tar.gz
   - CACHE_FILE_stretch=$CACHE_DIR/stretch.tar.gz
   - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
@@ -70,6 +71,11 @@ jobs:
     script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
     env: RELEASE=focal
+    dist: focal
+  - stage: build containers
+    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
+    rvm: 2.5
+    env: RELEASE=jammy
     dist: focal
   - stage: build containers
     script: travis_retry travis_wait 50 ./.travis/build_containers.sh
@@ -146,6 +152,21 @@ jobs:
   - stage: build packages
     script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=focal
+    dist: focal
+    rvm: 2.5
+    deploy:
+    - provider: gcs
+      access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
+      secret_access_key:
+        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
+      bucket: sd-agent-packages
+      acl: public-read
+      local_dir: "/serverdensity"
+      on:
+        all_branches: true
+  - stage: build packages
+    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
+    env: RELEASE=jammy
     dist: focal
     rvm: 2.5
     deploy:

--- a/.travis/build_containers.sh
+++ b/.travis/build_containers.sh
@@ -2,7 +2,7 @@
 set -ev
 echo "${RELEASE}"
 dockerfiles_dir=".travis/dockerfiles"
-deb=(bionic bullseye buster focal xenial trusty jessie stretch)
+deb=(bionic bullseye buster focal jammy xenial trusty jessie stretch)
 cd "$dockerfiles_dir"/"$RELEASE"
 if [ ! -d "$CACHE_DIR" ]; then
     sudo mkdir "$CACHE_DIR"

--- a/.travis/build_packages.sh
+++ b/.travis/build_packages.sh
@@ -7,7 +7,7 @@ else
     PACKAGES_DIR="/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_ID}/"
 fi
 
-deb=(bionic bullseye buster focal xenial trusty jessie stretch)
+deb=(bionic bullseye buster focal jammy  xenial trusty jessie stretch)
 CONTAINER="$RELEASE"
 echo "$CONTAINER"
 set -ev

--- a/.travis/dockerfiles/jammy/Dockerfile
+++ b/.travis/dockerfiles/jammy/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+WORKDIR /root
+RUN apt-get update && apt-get install -y pbuilder debootstrap devscripts ubuntu-dev-tools qemu qemu-user-static binfmt-support
+RUN echo 'for arch in amd64 arm64; do pbuilder-dist jammy $arch create; done' > /root/pbuilder-bootstrap.sh
+RUN apt-get install --reinstall qemu-user-static
+RUN echo 'PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt" \n\
+USENETWORK=yes \n\
+ ' >> /etc/pbuilderrc
+RUN chmod +x /root/pbuilder-bootstrap.sh
+COPY ./entrypoint.sh /
+CMD ["sh","/root/pbuilder-bootstrap.sh"]

--- a/.travis/dockerfiles/jammy/entrypoint.sh
+++ b/.travis/dockerfiles/jammy/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+DEBIAN_PATH="/sd-agent/debian"
+UBUNTU=(bionic focal jammy xenial trusty)
+
+if [[ ${UBUNTU[*]} =~ ${RELEASE} ]]
+then
+    DISTRO="ubuntu"
+else
+    DISTRO="debian"
+fi
+
+sudo cp -a ${DEBIAN_PATH}/distros/${RELEASE}/. ${DEBIAN_PATH}
+sudo sed -i "s|trusty|$RELEASE|" ${DEBIAN_PATH}/changelog
+sudo dpkg-source -b /sd-agent
+
+for ARCH in amd64 arm64; do
+    if [ ! -d /packages/${DISTRO}/${RELEASE} ]; then
+        sudo mkdir /packages/${DISTRO}/${RELEASE}
+    fi
+    if [ ! -d /packages/${DISTRO}/${RELEASE}/${ARCH} ]; then
+        sudo mkdir /packages/${DISTRO}/${RELEASE}/${ARCH}
+    fi
+    pbuilder-dist $RELEASE $arch update
+    pbuilder-dist ${RELEASE} ${ARCH} build \
+    --buildresult /packages/${DISTRO}/${RELEASE}/${ARCH} *${RELEASE}*.dsc
+done;

--- a/debian/distros/jammy/control
+++ b/debian/distros/jammy/control
@@ -1,0 +1,891 @@
+Source: sd-agent-core-plugins
+Section: python
+Priority: extra
+Maintainer: Server Density Developers <hello@serverdensity.com>
+Build-Depends: debhelper (>= 9), python2.7 (>= 2.7.0), python-setuptools,
+  python2.7-dev, libyaml-dev, libcurl4-gnutls-dev, postgresql-server-dev-all,
+  symlinks, curl, ca-certificates, libffi-dev, librrd-dev, libssl-dev,
+  build-essential, git
+Standards-Version: 3.9.5
+Vcs-Browser: https://github.com/serverdensity/sd-agent-core-plugins
+Vcs-Git: git://github.com/serverdensity/sd-agent-core-plugins.git
+Homepage: http://www.serverdensity.com/
+
+Package: sd-agent-sd-cpu-stats
+Architecture: all
+Breaks: sd-agent (<<2.2.0)
+Replaces: sd-agent (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - ServerDensity CPU stats plugin
+ Collects per CPU core stats.
+ .
+ This package installs the sd_cpu_stats plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-entropy
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Description: The Server Density monitoring agent - Entropy plugin
+ Collects available entropy.
+ .
+ This package installs the entropy plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cockroachdb
+Architecture: all
+Breaks: sd-agent (<<2.2.5)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.5)
+Description: The Server Density monitoring agent - CockroachDB plugin
+ Collects CockroachDB metrics.
+ .
+ This package installs the CockroachDB plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-btrfs
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - btrfs plugin
+ Monitor usage on Btrfs volumes so you can respond before they fill up.
+ .
+ This package installs the btrfs plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-activemq
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.0)
+Description: The Server Density monitoring agent - activemq plugin
+ Collect metrics for brokers and queues, producers and consumers, and more.
+ .
+ This package installs the activemq plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-openstack
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - openstack plugin
+ Track hypervisor and VM-level resource usage, plus Neutron metrics.
+ .
+ This package installs the openstack plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-supervisord
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - supervisord plugin
+ Monitor the status, uptime, and number of supervisor-managed processes.
+ .
+ This package installs the supervisord plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-hdfs-datanode
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - hdfs_datanode plugin
+ Track cluster disk usage, volume failures, dead DataNodes, and more.
+ .
+ This package installs the hdfs_datanode plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-zookeeper
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - zookeeper plugin
+ Track client connections and latencies, and know when requests are backing up.
+ .
+ This package installs the zookeeper plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-lighttpd
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - lighttpd plugin
+ Track uptime, bytes served, requests per second, response codes, and more.
+ .
+ This package installs the lighttpd plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kube-dns
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - kube_dns plugin
+ kube_dns description.
+ .
+ This package installs the kube_dns plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-fluentd
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - fluentd plugin
+ Monitor buffer queues and retry counts for each Fluentd plugin you've enabled.
+ .
+ This package installs the fluentd plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-snmp
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - snmp plugin
+ Collect SNMP metrics from your network devices.
+ .
+ This package installs the snmp plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-vsphere
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - vsphere plugin
+ Understand how vSphere resource usage affects your application.
+ .
+ This package installs the vsphere plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-tomcat
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.0)
+Description: The Server Density monitoring agent - tomcat plugin
+ Track requests per second, bytes served, cache hits, servlet metrics, and more.
+ .
+ This package installs the tomcat plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-system-core
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - system-core plugin
+ system_core description.
+ .
+ This package installs the system-core plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-phpfpm
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - phpfpm plugin
+ Monitor process states, slow requests, and accepted requests.
+ .
+ This package installs the phpfpm plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-elastic
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.3)
+Description: The Server Density monitoring agent - elastic plugin
+ Monitor overall cluster status down to JVM heap usage and everything in between.
+ .
+ This package installs the elastic plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-couchdb
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - couchdb plugin
+ Track and graph your CouchDB activity and performance metrics.
+ .
+ This package installs the couchdb plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ceph
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - ceph plugin
+ Collect per-pool performance metrics and monitor overall cluster status.
+ .
+ This package installs the ceph plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kubernetes-state
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - kubernetes_state plugin
+ kubernetes_state description.
+ .
+ This package installs the kubernetes_state plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-system-swap
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - system-swap plugin
+ Adds some optional swap memory checks.
+ .
+ This package installs the system-swap plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-twemproxy
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - twemproxy plugin
+ Visualize twemproxy performance and correlate with the rest of your applications
+ .
+ This package installs the twemproxy plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-network
+Architecture: all
+Breaks: sd-agent (<<2.2.0)
+Replaces: sd-agent (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - network plugin
+ network description.
+ .
+ This package installs the network plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kafka-consumer
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - kafka_consumer plugin
+ Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.
+ .
+ This package installs the kafka_consumer plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-hdfs-namenode
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - hdfs_namenode plugin
+ Track cluster disk usage, volume failures, dead DataNodes, and more.
+ .
+ This package installs the hdfs_namenode plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-marathon
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - marathon plugin
+ Track application metrics: required memory and disk, instance count, and more.
+ .
+ This package installs the marathon plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kong
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - kong plugin
+ Track total requests, response codes, client connections, and more.
+ .
+ This package installs the kong plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-gearmand
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - gearmand plugin
+ Track the number of jobs queued and running - in total or by task.
+ .
+ This package installs the gearmand plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-rabbitmq
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - rabbitmq plugin
+ Track queue size, consumer count, unacknowledged messages, and more.
+ .
+ This package installs the rabbitmq plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-docker
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - docker plugin
+ Correlate container performance with that of the services running inside them.
+ .
+ This package installs the docker plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-statsd
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - statsd plugin
+ Monitor the availability of StatsD servers and track metric counts.
+ .
+ This package installs the statsd plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-http-check
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Description: The Server Density monitoring agent - http_check plugin
+ http_check description.
+ .
+ This package installs the http_check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-gunicorn
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - gunicorn plugin
+ Monitor request rates and durations, log-message rates, and worker processes.
+ .
+ This package installs the gunicorn plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-yarn
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - yarn plugin
+ Collect cluster-wide health metrics and track application progress.
+ .
+ This package installs the yarn plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-varnish
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - varnish plugin
+ Track client and backend connections, cache misses and evictions, and more.
+ .
+ This package installs the varnish plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-directory
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - directory plugin
+ The Directory integration helps monitoring and reporting metrics on files for a provided directory.
+ .
+ This package installs the directory plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-activemq-xml
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - activemq_xml plugin
+ Collect metrics for brokers and queues, producers and consumers, and more.
+ .
+ This package installs the activemq_xml plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-solr
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.0)
+Description: The Server Density monitoring agent - solr plugin
+ Monitor request rate, handler errors, cache misses and evictions, and more.
+ .
+ This package installs the solr plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ntp
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - ntp plugin
+ ntp description.
+ .
+ This package installs the ntp plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-psycopg2-common
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), libpq5
+Breaks: sd-agent-pgbouncer (<<2.3.0)
+Replaces: sd-agent-pgbouncer (<<2.3.0)
+Description: The Server Density monitoring agent - common psycopg2 libs
+ This package provides the python psycopg2 module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-pyasn1-common
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), libpq5
+Breaks: sd-agent-ssh-check (<<2.3.0), sd-agent-snmp (<<2.3.0)
+Replaces: sd-agent-ssh-check (<<2.3.0), sd-agent-snmp (<<2.3.0)
+Description: The Server Density monitoring agent - common pyasn1 libs
+ This package provides the python pyasn1 module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+
+Package: sd-agent-postgresql
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Recommends: sd-agent-psycopg2-common
+Description: The Server Density monitoring agent - postgresql plugin
+ Collect a wealth of database performance and health metrics.
+ .
+ This package installs the postgresql plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-consul
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - consul plugin
+ Alert on Consul health checks, see service-to-node mappings, and much more.
+ .
+ This package installs the consul plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-nginx
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - nginx plugin
+ Monitor connection and request metrics. Get more metrics with NGINX Plus.
+ .
+ This package installs the nginx plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kafka
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.0)
+Description: The Server Density monitoring agent - kafka plugin
+ Collect metrics for producers and consumers, replication, max lag, and more.
+ .
+ This package installs the kafka plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kyototycoon
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - kyototycoon plugin
+ Track get, set, and delete operations; monitor replication lag.
+ .
+ This package installs the kyototycoon plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cassandra
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.0)
+Description: The Server Density monitoring agent - cassandra plugin
+ Track cluster performance, capacity, overall health, and much more.
+ .
+ This package installs the cassandra plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cassandra-nodetool
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-jmx (>= 2.2.1)
+Description: The Server Density monitoring agent - cassandra cluster plugin using nodetool
+ Track cluster performance, capacity, overall health, and much more.
+ .
+ This package installs the cassandra cluster plugin using nodetool.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mysql
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.1)
+Description: The Server Density monitoring agent - mysql plugin
+ Collect performance schema metrics, query throughput, custom metrics, and more.
+ .
+ This package installs the mysql plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-riakcs
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - riakcs plugin
+ Track the rate and mean latency of GETs, PUTs, DELETEs, and other operations.
+ .
+ This package installs the riakcs plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-etcd
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - etcd plugin
+ Track writes, updates, deletes, inter-node latencies, and more etcd metrics.
+ .
+ This package installs the etcd plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-redis
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - redis plugin
+ Track redis performance, memory use, blocked clients, evicted keys, and more.
+ .
+ This package installs the redis plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-disk
+Architecture: all
+Breaks: sd-agent (<<2.2.0)
+Replaces: sd-agent (<<2.2.0)
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - disk plugin
+ The disk check gathers metrics on mounted disks.
+ .
+ This package installs the disk plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-memcache
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - memcache plugin
+ Track memory use, hits, misses, evictions, fill percent, and more.
+ .
+ This package installs the memcache plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mongo
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - mongo plugin
+ Track read/write performance, most-used replicas, collection metrics, and more.
+ .
+ This package installs the mongo plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-tokumx
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), sd-agent-mongo (>= 2.2.0)
+Description: The Server Density monitoring agent - tokumx plugin
+ Track metrics for opcounters, replication lag, cache table size, and more.
+ .
+ This package installs the tokumx plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-postfix
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - postfix plugin
+ Monitor the size of all your Postfix queues.
+ .
+ This package installs the postfix plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-dns-check
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - dns-check plugin
+ dns_check description.
+ .
+ This package installs the dns-check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-pgbouncer
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0), sd-agent-psycopg2-common
+Description: The Server Density monitoring agent - pgbouncer plugin
+ Track connection pool metrics and monitor traffic to and from your application.
+ .
+ This package installs the pgbouncer plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-kubernetes
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - kubernetes plugin
+ Capture Pod scheduling events, track the status of your Kubelets, and much more.
+ .
+ This package installs the kubernetes plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-riak
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - riak plugin
+ Track node, vnode and ring performance metrics for RiakKV or RiakTS.
+ .
+ This package installs the riak plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mapreduce
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - mapreduce plugin
+ Monitor the status and duration of map and reduce tasks.
+ .
+ This package installs the mapreduce plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-powerdns-recursor
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - powerdns_recursor plugin
+ powerdns_recursor description.
+ .
+ This package installs the powerdns_recursor plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-agent-metrics
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - agent-metrics plugin
+ agent_metrics description.
+ .
+ This package installs the agent-metrics plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-apache
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - apache plugin
+ Track requests per second, bytes served, worker threads, uptime, and more.
+ .
+ This package installs the apache plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-linux-proc-extras
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - linux_proc_extras plugin
+ linux_proc_extras description.
+ .
+ This package installs the linux_proc_extras plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-spark
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - spark plugin
+ Track failed task rates, shuffled bytes, and much more.
+ .
+ This package installs the spark plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cacti
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent-mysql-common (>= 2.6.1), librrd8
+Description: The Server Density monitoring agent - cacti plugin
+ Forward your Cacti RRDs to Server Density for richer alerting and beautiful graphing.
+ .
+ This package installs the cacti plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-tcp-check
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - tcp_check plugin
+ tcp_check description.
+ .
+ This package installs the tcp_check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-process
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - process plugin
+ Capture metrics and monitor the status of running processes.
+ .
+ This package installs the process plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-haproxy
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.2)
+Description: The Server Density monitoring agent - haproxy plugin
+ Monitor key metrics for requests, responses, errors, bytes served, and more.
+ .
+ This package installs the haproxy plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-couchbase
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - couchbase plugin
+ Track and graph your Couchbase activity and performance metrics.
+ .
+ This package installs the couchbase plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-gitlab-runner
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - gitlab runner plugin
+ Track and graph your Gitlab runner activity and performance metrics.
+ .
+ This package installs the gitlab runner plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-gitlab
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - gitlab plugin
+ Track and graph your Gitlab activity and performance metrics.
+ .
+ This package installs the gitlab plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-go-expvar
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - go expvar plugin
+ Track and graph your go expvar metrics.
+ .
+ This package installs the go expvar plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-go-metro
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - go metro plugin
+ Track and graph your go metro metrics.
+ .
+ This package installs the go metro plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mesos-master
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - mesos master plugin
+ Track and graph your mesos master metrics.
+ .
+ This package installs the mesos master plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mesos-slave
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - mesos slave plugin
+ Track and graph your mesos slave metrics.
+ .
+ This package installs the mesos slave plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-nfsstat
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - nfsstat plugin
+ Track and graph your nfsstat metrics.
+ .
+ This package installs the nfsstat plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-oracle
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - oracle plugin
+ Track and graph your oracle metrics.
+ .
+ This package installs the oracle plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-storm
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.0)
+Description: The Server Density monitoring agent - storm plugin
+ Track and graph your storm metrics.
+ .
+ This package installs the storm plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mysql-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1), sd-agent-cryptography-common (>= 2.6.1)
+Breaks: sd-agent-mysql-common (<<2.6.1)
+Replaces: sd-agent-mysql-common (<<2.6.1)
+Description: This package provides the python mysql module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-cryptography-common
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Breaks: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Replaces: sd-agent-ssh-check (<<2.6.1), sd-agent-mysql (<<2.6.1)
+Description: This package provides the python cryptography module for plugins that require it
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-ssh-check
+Architecture: any
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2), libffi7, sd-agent-cryptography-common
+Recommends: sd-agent-pyasn1-common
+Description: The Server Density monitoring agent - ssh_check plugin
+ Monitor SSH connectivity and SFTP latency.
+ .
+ This package installs the ssh_check plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-jenkins
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.1.1)
+Description: The Server Density monitoring agent - jenkins plugin
+ Track and graph your jenkins metrics.
+ .
+ This package installs the jenkins plugin.
+ .
+ See https://www.serverdensity.com/ for more information.
+
+Package: sd-agent-mdadm
+Architecture: all
+Depends: ${python:Depends}, ${misc:Depends}, sd-agent (>= 2.2.2)
+Description: The Server Density monitoring agent - Mdadm plugin
+ Collects mdadm metrics.
+ .
+ This package installs the mdadm plugin.
+ .
+ See https://www.serverdensity.com/ for more information.

--- a/debian/distros/jammy/rules
+++ b/debian/distros/jammy/rules
@@ -89,7 +89,8 @@ zk
 
 override_dh_auto_build:
 	$(create_venv)
-
+	#Bump cryptography for Jammy builds
+	sed -i 's/cryptography==2.3/cryptography==3.3.2/g' ssh_check/requirements.txt
 	for plugin in ${PLUGINS}; do echo ${plugin}; $(BUILD_DIR)/bin/python2.7 $(BUILD_DIR)/bin/pip install --no-binary=:all: -r $${plugin}/requirements.txt; done
 
 override_dh_auto_clean:

--- a/debian/distros/jammy/rules
+++ b/debian/distros/jammy/rules
@@ -87,6 +87,9 @@ zk
 %:
 	dh $@
 
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip
+
 override_dh_auto_build:
 	$(create_venv)
 	#Bump cryptography for Jammy builds

--- a/debian/distros/jammy/rules
+++ b/debian/distros/jammy/rules
@@ -1,0 +1,108 @@
+#!/usr/bin/make -f
+
+BUILD_DIR=debian/build
+DEST_VENV=/usr/share/python/sd-agent
+PLUGINS=activemq_xml \
+agent_metrics \
+apache \
+btrfs \
+cacti \
+cassandra \
+cassandra_nodetool \
+ceph \
+cockroachdb \
+consul \
+couch \
+couchbase \
+directory \
+disk \
+dns_check \
+docker_daemon \
+elastic \
+entropy \
+etcd \
+fluentd \
+gearmand \
+gitlab \
+gitlab_runner \
+go_expvar \
+go-metro \
+gunicorn \
+haproxy \
+hdfs_datanode \
+hdfs_namenode \
+http_check \
+jenkins \
+kafka \
+kafka_consumer \
+kong \
+kube_dns \
+kubernetes \
+kubernetes_state \
+kyototycoon \
+lighttpd \
+linux_proc_extras \
+mapreduce \
+marathon \
+mcache \
+mdadm \
+mesos_master \
+mesos_slave \
+mongo \
+mysql \
+network \
+nfsstat \
+nginx \
+ntp \
+openstack \
+oracle \
+pgbouncer \
+php_fpm \
+postfix \
+postgres \
+powerdns_recursor \
+process \
+rabbitmq \
+redisdb \
+riak \
+riakcs \
+snmp \
+solr \
+spark \
+ssh_check \
+statsd \
+storm \
+supervisord \
+system_core \
+system_swap \
+tcp_check \
+tokumx \
+tomcat \
+twemproxy \
+varnish \
+vsphere \
+yarn \
+zk
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	$(create_venv)
+
+	for plugin in ${PLUGINS}; do echo ${plugin}; $(BUILD_DIR)/bin/python2.7 $(BUILD_DIR)/bin/pip install --no-binary=:all: -r $${plugin}/requirements.txt; done
+
+override_dh_auto_clean:
+	#rm -rf $(BUILD_DIR)
+
+override_dh_auto_install:
+	pyclean $(BUILD_DIR)
+
+define create_venv
+	curl -LO https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py
+	python2.7 virtualenv.py -p python2.7 --no-site-packages --no-pip --no-setuptools $(BUILD_DIR)
+	curl -LO https://bootstrap.pypa.io/ez_setup.py
+	$(BUILD_DIR)/bin/python2.7 ez_setup.py --version="44.1.1"
+	curl -LO https://bootstrap.pypa.io/pip/2.7/get-pip.py
+	$(BUILD_DIR)/bin/python2.7 get-pip.py
+endef

--- a/debian/distros/jammy/sd-agent-cryptography-common.install
+++ b/debian/distros/jammy/sd-agent-cryptography-common.install
@@ -1,0 +1,5 @@
+debian/build/lib/python2.7/site-packages/cryptography*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/enum*  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/_cffi_backend.so  usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/cffi* usr/share/python/sd-agent/lib/python2.7/site-packages
+debian/build/lib/python2.7/site-packages/pycparser* usr/share/python/sd-agent/lib/python2.7/site-packages

--- a/debian/distros/jammy/sd-agent-pyasn1-common.install
+++ b/debian/distros/jammy/sd-agent-pyasn1-common.install
@@ -1,0 +1,1 @@
+debian/build/lib/python2.7/site-packages/pyasn1*  usr/share/python/sd-agent/lib/python2.7/site-packages


### PR DESCRIPTION
This PR adds Jammy/Ubuntu 22 builds to travis.

* Had to bump cryptography for the build to succeed which was done via the rules, this changed the contents of the sd-agent-cryptography-common and sd-agent-pyasn1-common packages. 
* Had to make use of gzip compression instead of the standard zstd to allow the repo creation automation to complete. 