### PR TITLE
Remove jessie builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ env:
   - CACHE_FILE_buster=$CACHE_DIR/buster.tar.gz
   - CACHE_FILE_focal=$CACHE_DIR/focal.tar.gz
   - CACHE_FILE_jammy=$CACHE_DIR/jammy.tar.gz
-  - CACHE_FILE_jessie=$CACHE_DIR/jessie.tar.gz
   - CACHE_FILE_stretch=$CACHE_DIR/stretch.tar.gz
   - CACHE_FILE_xenial=$CACHE_DIR/xenial.tar.gz
   - conf_dir=conf.d
@@ -77,10 +76,6 @@ jobs:
     rvm: 2.5
     env: RELEASE=jammy
     dist: focal
-  - stage: build containers
-    script: travis_retry travis_wait 50 ./.travis/build_containers.sh
-    rvm: 2.5
-    env: RELEASE=jessie
   - stage: build containers
     script: travis_retry travis_wait 50 ./.travis/build_containers.sh
     rvm: 2.5
@@ -168,20 +163,6 @@ jobs:
     script: travis_retry travis_wait 50 ./.travis/build_packages.sh
     env: RELEASE=jammy
     dist: focal
-    rvm: 2.5
-    deploy:
-    - provider: gcs
-      access_key_id: GOOGQSTXHRV5ODGTXK2GT4U4
-      secret_access_key:
-        secure: zyn6V6ohrSeVb5t/th5LmmsTZDZcD1VCfiiMN1cF+ICM/82mTahTWiefQzgkhGwa1c+eRRq+uG+1pK2tLDu0u9cu4H+wQb3uRStCWalscpP5j2Y0Si7K4Bx28bUm/+fQpi0BkOxXIlwmmCR1eINqjT6WyTqYRHzE5S03twnk8h0dlV0kNANU7sYv/ObizLlM8Jz04ztueCO2EXbrxKYrSg0+0LQYPUzPI8fUICXlTPvVbh2py3TYNo7U7h6swudu5cmZJt4I/hurx+R/NjVaUH8mWlrNOrVsYG+iMv7kx/Dx4tKWAadC8jYToyrETxdKG0SXLMdK/48HecEn2fOiIFIUuCwwj5nNGdvyFGFn5iuVFx2pdDs90w/EGawbSZ6WGR0AooYt0KjPiZ90uhZzvPodE6TSlr+47pkl02mcmH54cXTg1fAxu5+8P52cx7mGRnP5IY6hwgOYqawz9swMf48J0dJqKqKRMg5lg8h6+lodKYHKZJsiqH7cAhtoh5R0k4OMV32z8wVwNvTdw+fYsLOxaMuT0iWzWBoOnAeOczTr1WQZS0gSqTyQ1FnexyLLzY7EYmgRjEzD6png5lCTD2OaM3DvOCvrIpGBONyPQFo92MRVedpGksBZ+rzWCy6f4ZbwAO85uX4KokgUo+jp2QS78j0512yCjYb4sz//CF4=
-      bucket: sd-agent-packages
-      acl: public-read
-      local_dir: "/serverdensity"
-      on:
-        all_branches: true
-  - stage: build packages
-    script: travis_retry travis_wait 50 ./.travis/build_packages.sh
-    env: RELEASE=jessie
     rvm: 2.5
     deploy:
     - provider: gcs


### PR DESCRIPTION
This PR removes Jessie builds from the Travis config.

Jessie is EoL for years and the builds are now failing. We have old builds and will preserve an old version of the agent for Jessie in the repos, per other EoL OS. 

@pessoa to review. 