### PR TITLE
Bump version to 2.6.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - PIP_CACHE=$HOME/.cache/pip
   - VOLATILE_DIR=/tmp
   - DD_CASHER_DIR=/tmp/casher
-  - AGENT_VERSION=2.6.6
+  - AGENT_VERSION=2.6.7
   - CACHE_DIR=$HOME/.cache
   - CACHE_FILE_el7=$CACHE_DIR/el7.tar.gz
   - CACHE_FILE_el7_arm=$CACHE_DIR/el7_arm.tar.gz

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sd-agent-core-plugins (2.6.7-1trusty0) trusty; urgency=medium
+
+  * MySQL: Fixes compatibility with MariaDB 10.10.
+
+ -- Server Density <hello@serverdensity.com>  Thu, 2 Mar 2023 10:00:00 +0100
+
 sd-agent-core-plugins (2.6.6-1trusty0) trusty; urgency=medium
 
   * Process: Fix metric tagging ensuring alerts trigger

--- a/packaging/el/inc/changelog
+++ b/packaging/el/inc/changelog
@@ -1,4 +1,6 @@
 %changelog
+* Thu Mar 2 2023 Server Density <hello@serverdensity.com> 2.6.7-1
+- MySQL: Fixes compatibility with MariaDB 10.10.
 * Wed Mar 30 2022 Server Density <hello@serverdensity.com> 2.6.6-1
 - Process: Fix metric tagging ensuring alerts trigger
 * Mon Jan 10 2022 Server Density <hello@serverdensity.com> 2.6.5-1

--- a/packaging/el/inc/version
+++ b/packaging/el/inc/version
@@ -1,1 +1,1 @@
-Version: 2.6.6
+Version: 2.6.7


### PR DESCRIPTION
This PR bumps the packaging version to 2.6.7, ready for release. 

Ideally this should be merged last, after #75 and #76 

@pessoa to review